### PR TITLE
fix: work without VPN when GitHub is unreachable

### DIFF
--- a/include/common/network.h
+++ b/include/common/network.h
@@ -23,6 +23,8 @@
 #include <stop_token>
 #include <string_view>
 #include <filesystem>
+#include <mutex>
+#include <optional>
 #include <windows.h>
 #include <wininet.h>
 
@@ -36,9 +38,23 @@ class internet_t final {
 private:
     static constexpr DWORD internet_flags =
         INTERNET_FLAG_RELOAD | INTERNET_FLAG_NO_CACHE_WRITE | INTERNET_FLAG_SECURE;
-    
+
+    /// Timeout (ms) for each request phase (connect/send/receive); otherwise a block without VPN
+    /// would hang on WinINet's defaults for tens of seconds.
+    static constexpr DWORD timeout_ms = 5000;
+
     bool valid = true;
     std::stop_token stop_token;
+
+    // close_handles() may be called concurrently by the destructor and the stop-callback from
+    // different threads — the mutex + flag close the handles exactly once.
+    std::mutex handles_mutex;
+    bool handles_closed = false;
+    std::optional<std::stop_callback<std::function<void()>>> stop_cb;
+
+    /// Close the WinINet handles exactly once (thread-safe). From the stop-callback it closes the
+    /// session, interrupting a blocking InternetOpenUrl/InternetReadFile on another thread.
+    auto close_handles() noexcept -> void;
 public:
     /// Callback function type for reading file data.
     ///
@@ -46,8 +62,8 @@ public:
     /// @param bytes_read[in] Number of bytes read into buffer.
     using read_file_callback_t = std::function<void(char buffer[4096], std::size_t bytes_read)>;
 
-    HINTERNET handle; ///< WinINet Internet Handle.
-    HINTERNET url;    ///< WinINet URL Handle.
+    HINTERNET handle;       ///< WinINet Internet Handle.
+    HINTERNET url = nullptr; ///< WinINet URL Handle.
     
     /// Check if internet connection is available.
     ///

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -21,6 +21,39 @@
 #include <windows.h>
 #include <wininet.h>
 #include <fstream>
+#include <functional>
+#include <mutex>
+
+namespace {
+
+/// Timeouts on every phase + no retries: a request blocked without VPN fails after
+/// `timeout_ms` instead of hanging on WinINet's defaults for tens of seconds.
+auto set_timeouts(HINTERNET handle, DWORD timeout_ms) -> void {
+    DWORD timeout = timeout_ms;
+    DWORD retries = 1;
+
+    InternetSetOption(handle, INTERNET_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+    InternetSetOption(handle, INTERNET_OPTION_SEND_TIMEOUT,    &timeout, sizeof(timeout));
+    InternetSetOption(handle, INTERNET_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+    InternetSetOption(handle, INTERNET_OPTION_CONNECT_RETRIES, &retries, sizeof(retries));
+}
+
+} // namespace
+
+auto common::internet_t::close_handles() noexcept -> void {
+    std::scoped_lock lock(handles_mutex);
+
+    if (handles_closed)
+        return;
+
+    handles_closed = true;
+
+    if (url)
+        InternetCloseHandle(url);
+
+    if (handle)
+        InternetCloseHandle(handle);
+}
 
 auto common::internet_t::read_file(read_file_callback_t callback) const -> bool {
     char buffer[4096];
@@ -45,18 +78,37 @@ common::internet_t::internet_t(const std::string_view& link, std::stop_token sto
         return;
     }
 
-    if (url = InternetOpenUrl(handle, std::string(link).c_str(), nullptr, 0, internet_flags, 0); url)
+    set_timeouts(handle, timeout_ms);
+
+    // Closing the session handle from the stop-callback interrupts a blocking InternetOpenUrl/
+    // InternetReadFile on request_stop (thread join), without waiting for the timeout.
+    stop_cb.emplace(this->stop_token, std::function<void()>([this] { close_handles(); }));
+
+    HINTERNET opened = InternetOpenUrl(handle, std::string(link).c_str(), nullptr, 0, internet_flags, 0);
+
+    std::scoped_lock lock(handles_mutex);
+
+    if (handles_closed) {
+        // stop arrived during connect: the session is already closed; close the orphaned URL handle.
+        if (opened)
+            InternetCloseHandle(opened);
+
+        valid = false;
         return;
-    
-    close_handlers(handle);
+    }
+
+    if (opened) {
+        url = opened;
+        return;
+    }
+
     valid = false;
 }
 
 common::internet_t::~internet_t() noexcept {
-    if (!valid)
-        return;
-
-    close_handlers(handle, url);
+    // Remove the callback before closing (it captures this); reset() waits for it if it's running.
+    stop_cb.reset();
+    close_handles();
 }
 
 auto common::network::download_file(const std::string_view& url, const std::filesystem::path& output,
@@ -94,6 +146,10 @@ auto common::network::send_get_request(const std::string_view& url, std::stop_to
     if (!internet)
         return "";
 
+    // The loader calls this synchronously before loading the plugin: without a timeout a block
+    // on api.github.com (no VPN) would delay the plugin load itself.
+    set_timeouts(internet, 5000);
+
     URL_COMPONENTS url_components;
     ZeroMemory(&url_components, sizeof(url_components));
     url_components.dwStructSize = sizeof(url_components);
@@ -102,7 +158,11 @@ auto common::network::send_get_request(const std::string_view& url, std::stop_to
     url_components.dwUrlPathLength = -1;
     url_components.dwExtraInfoLength = -1;
 
-    if (!InternetCrackUrl(std::string(url).c_str(), url.length(), 0, &url_components)) {
+    // InternetCrackUrl with -1 lengths doesn't copy the string; it points lpszHostName/lpszUrlPath
+    // into the buffer, which must outlive the reads below — hence a named, non-temporary string.
+    std::string url_string(url);
+
+    if (!InternetCrackUrl(url_string.c_str(), url_string.length(), 0, &url_components)) {
         internet_t::close_handlers(internet);
         return "";
     }


### PR DESCRIPTION
Without a VPN, providers that block api.github.com and raw.githubusercontent.com (e.g. RU DPI) made GAdmin's WinINet requests hang: the requests had no timeout and the connect phase was not cancelable.

A blackholed connection blocked for the WinINet default (tens of seconds) in a background thread. This stalled the font-download queue (which gates render init, so the GUI never appeared) and could crash the game when a std::jthread was joined or reassigned while stuck in a blocking connect (nickname_colors reassigns its downloader every 5 min; windows_customization and fonts join on unload).

- Set CONNECT/SEND/RECEIVE timeouts (5s) and CONNECT_RETRIES=1 on the WinINet session handle, so a blocked request fails in ~5s instead of hanging.
- Add a std::stop_callback to internet_t that closes the session handle to interrupt a blocking InternetOpenUrl/InternetReadFile immediately on stop, so join() never waits even the timeout. Close handles exactly once under a mutex (this also fixes a handle leak on a failed InternetOpenUrl).
- Set the timeout on send_get_request (the loader's update check) too, and fix a use-after-free there: InternetCrackUrl with length -1 stores pointers into the input buffer, which must outlive the later host/path reads.