### PR TITLE
3 new features

### DIFF
--- a/embed/configuration.json
+++ b/embed/configuration.json
@@ -164,6 +164,7 @@
         "nickname_colors": true,
         "auto_aa_command": false,
         "display_id_in_chat": false,
+        "me_to_id": true,
         "auto_alogin": false,
         "fix_chat_opening": true,
 

--- a/embed/configuration.json
+++ b/embed/configuration.json
@@ -117,7 +117,8 @@
 
         "interaction_area": {
             "use": false,
-            "radius": 300
+            "radius": 300,
+            "ignore_spectated_target": true
         },
 
         "player_checker": {

--- a/embed/main_frame_settings.json
+++ b/embed/main_frame_settings.json
@@ -154,6 +154,10 @@
         "interaction_area": {
             "_type": "subsection",
             "_name": "Круговая панель",
+            "ignore_spectated_target": {
+                "_type": "bool",
+                "_name": "Не наводиться на объект слежки"
+            },
             "radius": {
                 "_type": "intrange",
                 "_name": "Радиус",

--- a/embed/main_frame_settings.json
+++ b/embed/main_frame_settings.json
@@ -235,6 +235,7 @@
         "nickname_colors": { "_type": "bool", "_name": "Цветные никнеймы в /a" },
         "auto_aa_command": { "_type": "bool", "_name": "Автоматический /aa" },
         "display_id_in_chat": { "_type": "bool", "_name": "Отображать ID в IC чате" },
+        "me_to_id": { "_type": "bool", "_name": "Заменять 'me' на свой ID в командах" },
         "auto_alogin": { "_type": "bool", "_name": "/alogin после спавна" },
         "fix_chat_opening": { "_type": "bool", "_name": "Исправление открытия чата на Т" },
         "auto_login": {

--- a/include/plugin/gui/hotkey.h
+++ b/include/plugin/gui/hotkey.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <functional>
 #include <imgui.h>
+#include <nlohmann/json_fwd.hpp>
 
 namespace plugin {
 
@@ -204,6 +205,14 @@ private:
     hotkey_handler* handler;
     key_bind new_bind;
 
+    /// Optional external storage for this hotkey's bind (a `{ label: packed }` JSON object).
+    /// When set, the bind is read from / written to it instead of the live configuration —
+    /// used to edit a preset's stored hotkeys without touching the live binds.
+    nlohmann::json* external_storage = nullptr;
+
+    /// The bind storage to use (external if set, otherwise the live configuration's hotkeys).
+    auto saved_binds() -> nlohmann::json&;
+
     auto truncate_text_in_button(float button_width, const std::string_view& text) const -> std::string;
     auto hint_renderer() -> void;
     auto hint_condition() -> bool;
@@ -228,6 +237,10 @@ public:
     /// @param size[in] Button size (default: `default_button_size`).
     auto render(const ImVec2& size = default_button_size) -> void;
 
+    /// Programmatically open this hotkey's activation-conditions popup (the same popup as
+    /// the right-click on the bind button), e.g. from a click on the hotkey's label.
+    auto open_conditions_popup() -> void;
+
     /// Construct hotkey with the specific callback passed.
     ///
     /// @param new_callback[in] New callback to set.
@@ -244,6 +257,19 @@ public:
     ///
     /// @return Reference to this hotkey to allow chain-calls.
     inline auto without_rendering_in_settings() -> hotkey&;
+
+    /// Bind this hotkey's storage to an external `{ label: packed }` JSON object and reload
+    /// its bind from it (used to edit a preset's hotkeys independently of the live binds).
+    ///
+    /// @param storage[in] Pointer to the external storage object.
+    /// @return            Reference to this hotkey to allow chain-calls.
+    auto bind_to_external(nlohmann::json* storage) -> hotkey&;
+
+    /// Update only the external storage pointer (without reloading the bind). Call every
+    /// frame to keep the pointer valid if the container holding the storage reallocates.
+    ///
+    /// @param storage[in] Pointer to the external storage object.
+    auto set_external_storage(nlohmann::json* storage) -> void;
 
     /// Construct hotkey with label and bind.
     ///

--- a/include/plugin/gui/widgets/button.h
+++ b/include/plugin/gui/widgets/button.h
@@ -47,6 +47,7 @@ private:
 
     ImVec2 size;
     ImDrawFlags draw_flags = ImDrawFlags_RoundCornersAll;
+    bool draw_click_animation = true;
 
     static inline std::unordered_map<std::string, configuration_t> pool;
    
@@ -61,10 +62,15 @@ public:
     inline auto with_draw_flags(ImDrawFlags new_draw_flags) noexcept -> button&;
 
     /// Set the animation durations for the button.
-    /// 
+    ///
     /// @param new_durations[in] New durations to set.
     /// @return                  Reference to the button object to allow construction be chain-called.
     inline auto with_durations(const std::array<std::chrono::milliseconds, 3>& durations) noexcept -> button&;
+
+    /// Disable the click ripple animation (the hover border is kept).
+    ///
+    /// @return Reference to the button object to allow construction be chain-called.
+    inline auto without_click_animation() noexcept -> button&;
 
     /// Render the button.
     /// 
@@ -108,6 +114,11 @@ inline auto plugin::gui::widgets::button::with_durations(const std::array<std::c
     noexcept -> button&
 {
     durations = std::move(new_durations);
+    return *this;
+}
+
+inline auto plugin::gui::widgets::button::without_click_animation() noexcept -> button& {
+    draw_click_animation = false;
     return *this;
 }
 

--- a/include/plugin/gui/windows/main/frames/presets.h
+++ b/include/plugin/gui/windows/main/frames/presets.h
@@ -65,6 +65,11 @@ private:
     }; // static constexpr types::zstring_t captured_sections[]
 
     types::not_null<initializer*> child;
+
+    /// Owning settings frame, reused to render the per-option editing widgets so the
+    /// rendering logic is not duplicated.
+    types::not_null<settings*> owner;
+
     widgets::submenu submenu = widgets::submenu("Пресеты##frames::presets");
     gui::widgets::search editor_search = gui::widgets::search("presets::editor_search");
 
@@ -90,7 +95,7 @@ private:
     /// is being actively edited, to avoid writing the file on every dragged frame).
     bool pending_save = false;
 
-    /// State of the "Чекер игроков" editor section (the player list lives in the preset).
+    /// State of the player-checker editor section (the player list lives in the preset).
     std::string pc_nickname_input;
     std::string pc_description_input;
     std::size_t pc_selected_index = 0;
@@ -113,14 +118,10 @@ private:
     /// Capture every editable (non-secret) item of all captured sections.
     auto capture_all() const -> nlohmann::json;
 
-    /// Snapshot the live hotkeys (those shown in the "Горячие клавиши" frame) as a
+    /// Snapshot the live hotkeys (those shown in the hotkeys frame) as a
     /// `{ label: packed_bind }` object, and the live player-checker list, respectively.
     auto capture_hotkeys() const -> nlohmann::json;
     auto capture_player_checker() const -> nlohmann::json;
-
-    /// Refresh the values of the items already included in the preset from the live
-    /// configuration, without changing which items are included.
-    auto refresh_values(nlohmann::json& preset) const -> void;
 
     /// Apply the preset to the live configuration (only the included items).
     auto apply_preset(const nlohmann::json& preset) const -> void;
@@ -160,11 +161,11 @@ private:
     /// preset does not have yet, e.g. an older preset or a setting added in a later version).
     auto include_item(const std::string& section, const std::string& item, nlohmann::json& settings) const -> void;
 
-    auto render_editor(nlohmann::json& preset) -> void;
+    auto render_editor(nlohmann::json& preset, float bottom_reserve) -> void;
     auto render_section_editor(const std::string& section, nlohmann::ordered_json& meta_section,
                                nlohmann::json& settings) -> void;
 
-    /// Render the "Горячие клавиши" / "Чекер игроков" editor sections inline (editing the
+    /// Render the hotkeys / player-checker editor sections inline (editing the
     /// data stored in the preset, independently of the live configuration).
     auto render_hotkeys_section(nlohmann::json& settings, int preset_id) -> void;
     auto render_player_checker_section(nlohmann::json& settings) -> void;
@@ -178,12 +179,6 @@ private:
     /// regular settings frame does (but editing the preset's snapshot instead of the live config).
     auto open_subsection_popup(const std::string& section, const std::string& item, const std::string& name,
                                nlohmann::ordered_json& meta_item, nlohmann::json& settings) -> void;
-    auto render_option(const std::string& id, const std::string& key, const std::string& subsection_key,
-                       nlohmann::ordered_json& meta_option, nlohmann::json& parent) -> void;
-    auto render_variant(const std::string& id, nlohmann::ordered_json& config, nlohmann::json& value) -> void;
-    auto render_color(const std::string& id, nlohmann::json& value) -> void;
-    auto render_custom(const std::string& custom_id, nlohmann::json& value) -> void;
-
     auto frame_renderer(std::string& label, std::any& payload) -> void;
     auto add_callback() -> void;
     auto on_entry_destroyed(std::size_t index) -> void;
@@ -193,7 +188,8 @@ public:
     /// Construct the frame.
     ///
     /// @param child[in] Valid pointer to the main window.
-    explicit presets(types::not_null<initializer*> child);
+    /// @param owner[in] Owning settings frame, reused for the option-editing widgets.
+    presets(types::not_null<initializer*> child, types::not_null<settings*> owner);
 }; // class presets final
 
 } // namespace plugin::gui::windows::main::frames

--- a/include/plugin/gui/windows/main/frames/presets.h
+++ b/include/plugin/gui/windows/main/frames/presets.h
@@ -1,0 +1,201 @@
+/// GAdmin - Plugin simplifying the work of administrators on the Gambit-RP
+/// Copyright (C) 2023-2026 The Contributors.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef GADMIN_PLUGIN_GUI_WINDOWS_MAIN_FRAMES_PRESETS_H
+#define GADMIN_PLUGIN_GUI_WINDOWS_MAIN_FRAMES_PRESETS_H
+
+#include "plugin/gui/windows/main/initializer.h"
+#include "plugin/gui/windows/main/base/frame.h"
+#include "plugin/gui/windows/main/frames/settings.h"
+#include "plugin/gui/windows/main/widgets/submenu.h"
+#include "plugin/gui/windows/main/widgets/popup.h"
+#include "plugin/gui/widgets/search.h"
+#include "plugin/gui/hotkey.h"
+#include "plugin/types/not_null.h"
+#include "plugin/types/simple.h"
+#include <nlohmann/json.hpp>
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace plugin::gui::windows::main::frames {
+
+/// Represents the settings presets frame in the main window.
+///
+/// Allows the user to save the current script settings as a named preset, choose in a
+/// detailed editor which settings are part of the preset (and edit their values without
+/// touching the live configuration), apply a preset, rename, refresh or delete it. Presets
+/// are stored in a separate human-readable JSON file so they can be shared between users.
+/// Secrets (account/alogin passwords) and the internal UI state are never captured.
+class presets final : public basic_frame {
+private:
+    using item_type = settings::item_type;
+
+    static constexpr float title_font_size = 24;
+    static constexpr float common_font_size = 18;
+    static constexpr float buttons_height = 30;
+
+    /// Hotkey badge (drawn over a preset entry in the side list) geometry.
+    static constexpr float badge_font_size = 14;
+    static constexpr float badge_padding_x = 6.0f;
+    static constexpr float badge_padding_y = 2.0f;
+    static constexpr float badge_right_margin = 6.0f;
+    static constexpr float badge_text_gap = 8.0f; ///< Gap reserved between the name and the badge.
+
+    /// Configuration sections a preset may capture.
+    static constexpr types::zstring_t captured_sections[] = {
+        "windows", "cheats", "misc", "spectator_mode"
+    }; // static constexpr types::zstring_t captured_sections[]
+
+    types::not_null<initializer*> child;
+    widgets::submenu submenu = widgets::submenu("Пресеты##frames::presets");
+    gui::widgets::search editor_search = gui::widgets::search("presets::editor_search");
+
+    /// Shared popup used to edit the detailed options of a subsection (mirrors the popup
+    /// of the regular settings frame, so the preset editor feels like the settings screen).
+    widgets::popup popup = widgets::popup("frames::presets::editor_popup");
+
+    ImFont* bold_font = nullptr;
+    ImFont* regular_font = nullptr;
+    ImFont* icon_font = nullptr;
+
+    std::filesystem::path presets_file;
+    nlohmann::json preset_list = nlohmann::json::array();
+
+    /// Next stable preset id to assign. Ids are used to bind hotkeys to presets
+    /// independently of their order or name.
+    int next_id = 1;
+
+    /// Settings tree metadata (parsed from `main_frame_settings.json`).
+    nlohmann::ordered_json options;
+
+    /// Whether an editor change is waiting to be written to disk (flushed when no widget
+    /// is being actively edited, to avoid writing the file on every dragged frame).
+    bool pending_save = false;
+
+    /// State of the "Чекер игроков" editor section (the player list lives in the preset).
+    std::string pc_nickname_input;
+    std::string pc_description_input;
+    std::size_t pc_selected_index = 0;
+
+    /// Per-preset hotkey editor objects: the real hotkey widget (with its key capture and
+    /// activation-conditions popup) bound to the preset's hotkeys storage instead of the
+    /// live binds. Rebuilt when the selected preset changes.
+    std::vector<gui::hotkey> hotkey_editors;
+    int hotkey_editors_preset_id = -1;
+
+    auto load_presets() -> void;
+    auto save_presets() const -> void;
+
+    /// Whether the given configuration item must never enter a preset (passwords).
+    static auto is_secret(const std::string& section, const std::string& item) -> bool;
+
+    /// Snapshot a single configuration item from the live configuration.
+    auto snapshot_item(const std::string& section, const std::string& item) const -> nlohmann::json;
+
+    /// Capture every editable (non-secret) item of all captured sections.
+    auto capture_all() const -> nlohmann::json;
+
+    /// Snapshot the live hotkeys (those shown in the "Горячие клавиши" frame) as a
+    /// `{ label: packed_bind }` object, and the live player-checker list, respectively.
+    auto capture_hotkeys() const -> nlohmann::json;
+    auto capture_player_checker() const -> nlohmann::json;
+
+    /// Refresh the values of the items already included in the preset from the live
+    /// configuration, without changing which items are included.
+    auto refresh_values(nlohmann::json& preset) const -> void;
+
+    /// Apply the preset to the live configuration (only the included items).
+    auto apply_preset(const nlohmann::json& preset) const -> void;
+
+    /// Index of the last applied (active) preset, or -1 if none. Persisted in the config.
+    auto get_active_index() const -> int;
+    auto set_active_index(int index) const -> void;
+
+    /// Whether every included item of the preset currently equals the live configuration.
+    auto preset_matches_live(const nlohmann::json& preset) const -> bool;
+
+    /// Ensure every preset has a unique stable id; assign to those missing one.
+    auto ensure_preset_ids() -> void;
+
+    /// Hotkey label (and config key) for the preset with the given id.
+    static auto preset_hotkey_label(int id) -> std::string;
+
+    /// Register a global hotkey that applies the preset with the given id.
+    auto register_preset_hotkey(int id) -> void;
+
+    /// Find the pooled hotkey with the given label (so its bind can be rendered/edited).
+    auto find_pool_hotkey(const std::string& label) const -> gui::hotkey*;
+
+    /// Textual representation of the preset entry's apply hotkey, or std::nullopt if the
+    /// entry has no assigned key bind (used to draw / reserve space for its badge).
+    auto entry_hotkey_text(std::size_t index) -> std::optional<std::string>;
+
+    /// Apply the preset with the given id (called by its hotkey).
+    auto apply_preset_by_id(int id) -> void;
+
+    /// Render the "applied / not applied / modified" status banner for a preset.
+    auto render_status_banner(const nlohmann::json& preset, std::size_t index) const -> void;
+
+    auto render_editable_name(std::string& frame_label, std::string& value) -> void;
+
+    /// Snapshot a single item's live value into the preset (used to fill in values that the
+    /// preset does not have yet, e.g. an older preset or a setting added in a later version).
+    auto include_item(const std::string& section, const std::string& item, nlohmann::json& settings) const -> void;
+
+    auto render_editor(nlohmann::json& preset) -> void;
+    auto render_section_editor(const std::string& section, nlohmann::ordered_json& meta_section,
+                               nlohmann::json& settings) -> void;
+
+    /// Render the "Горячие клавиши" / "Чекер игроков" editor sections inline (editing the
+    /// data stored in the preset, independently of the live configuration).
+    auto render_hotkeys_section(nlohmann::json& settings, int preset_id) -> void;
+    auto render_player_checker_section(nlohmann::json& settings) -> void;
+    auto render_player_checker_body(nlohmann::json& players) -> void;
+
+    /// (Re)build the per-preset hotkey editor objects when the selected preset changes,
+    /// binding each to the preset's hotkeys storage.
+    auto ensure_hotkey_editors(nlohmann::json& hotkeys, int preset_id) -> void;
+
+    /// Open the shared popup to edit the detailed options of a subsection, exactly like the
+    /// regular settings frame does (but editing the preset's snapshot instead of the live config).
+    auto open_subsection_popup(const std::string& section, const std::string& item, const std::string& name,
+                               nlohmann::ordered_json& meta_item, nlohmann::json& settings) -> void;
+    auto render_option(const std::string& id, const std::string& key, const std::string& subsection_key,
+                       nlohmann::ordered_json& meta_option, nlohmann::json& parent) -> void;
+    auto render_variant(const std::string& id, nlohmann::ordered_json& config, nlohmann::json& value) -> void;
+    auto render_color(const std::string& id, nlohmann::json& value) -> void;
+    auto render_custom(const std::string& custom_id, nlohmann::json& value) -> void;
+
+    auto frame_renderer(std::string& label, std::any& payload) -> void;
+    auto add_callback() -> void;
+    auto on_entry_destroyed(std::size_t index) -> void;
+public:
+    auto render() -> void override;
+
+    /// Construct the frame.
+    ///
+    /// @param child[in] Valid pointer to the main window.
+    explicit presets(types::not_null<initializer*> child);
+}; // class presets final
+
+} // namespace plugin::gui::windows::main::frames
+
+#endif // GADMIN_PLUGIN_GUI_WINDOWS_MAIN_FRAMES_PRESETS_H

--- a/include/plugin/gui/windows/main/frames/settings.h
+++ b/include/plugin/gui/windows/main/frames/settings.h
@@ -26,8 +26,12 @@
 #include "plugin/types/not_null.h"
 #include "plugin/types/simple.h"
 #include <nlohmann/json.hpp>
+#include <memory>
 
 namespace plugin::gui::windows::main::frames {
+
+/// Presets manager, embedded as a section of the settings frame.
+class presets;
 
 /// Represents the settings frame in the main window.
 class settings final : public basic_frame {
@@ -45,6 +49,12 @@ private:
     nlohmann::ordered_json options;
     types::not_null<initializer*> child;
     std::string guide_hint_id = "";
+
+    /// Sentinel key used for the embedded presets section entry.
+    static constexpr types::zstring_t presets_section_key = "__presets__";
+
+    /// Embedded presets manager rendered when the presets section is selected.
+    std::unique_ptr<presets> presets_component;
 
     ImFont* bold_font = nullptr;
     ImFont* regular_font = nullptr;
@@ -80,6 +90,9 @@ public:
     ///
     /// @param child[in] Valid pointer to the main window.
     explicit settings(types::not_null<initializer*> child);
+
+    /// Destructor (out-of-line so the incomplete `presets` member can be destroyed).
+    ~settings() override;
 }; // class settings final
 
 NLOHMANN_JSON_SERIALIZE_ENUM(settings::item_type, {

--- a/include/plugin/gui/windows/main/frames/settings.h
+++ b/include/plugin/gui/windows/main/frames/settings.h
@@ -72,6 +72,14 @@ private:
     auto render_custom(const std::string_view& id, nlohmann::json& setter) const -> void;
     auto render_boolean(const std::string_view& label, nlohmann::ordered_json& config, bool& setter) const -> void;
 public:
+    /// Render the editing widget for one option of the given meta type into `value`. Shared
+    /// with the presets editor so the per-type rendering is not duplicated. `widget_id` must
+    /// start with "##" and be unique; `custom_id` identifies the custom editor for custom
+    /// options. When `live` is false, side effects (toggle events) are suppressed, so editing
+    /// a preset snapshot never touches the running state.
+    auto render_option_widget(const std::string& widget_id, const std::string& custom_id,
+                              nlohmann::ordered_json& meta_option, nlohmann::json& value, bool live) const -> void;
+
     /// Item types to parse from the JSON and later to render them.
     enum class item_type : std::uint8_t {
         subsection,     ///< Represents the group of settings.

--- a/include/plugin/gui/windows/main/widgets/submenu.h
+++ b/include/plugin/gui/windows/main/widgets/submenu.h
@@ -25,6 +25,8 @@
 #include <any>
 #include <vector>
 #include <functional>
+#include <optional>
+#include <cstdint>
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -46,6 +48,26 @@ public:
 
     /// Callback type for handling new entry addition.
     using add_callback_t = std::function<void()>;
+
+    /// Callback type for decorating an entry's displayed label (e.g. to mark an active
+    /// entry). Receives the entry index and its raw label, returns the text to display.
+    using label_decorator_t = std::function<std::string(std::size_t index, const std::string& label)>;
+
+    /// Callback type for highlighting an entry by overriding its button background color
+    /// (e.g. to mark the active entry). Receives the entry index, returns a packed ImU32
+    /// color, or std::nullopt to keep the default button color.
+    using entry_highlight_t = std::function<std::optional<std::uint32_t>(std::size_t index)>;
+
+    /// Callback type for drawing extra content over an entry after its button is rendered
+    /// (e.g. a small hotkey badge). Receives the entry index and the button's screen-space
+    /// rectangle (top-left and bottom-right corners).
+    using entry_overlay_t = std::function<void(std::size_t index, const ImVec2& min, const ImVec2& max)>;
+
+    /// Callback type for reserving horizontal space on the right side of an entry's label
+    /// (e.g. for an overlay badge), so the label is truncated with an ellipsis instead of
+    /// being drawn under the overlay. Receives the entry index, returns the width in pixels
+    /// to reserve (0 for none). When set, entry labels are left-aligned.
+    using entry_text_reserve_t = std::function<float(std::size_t index)>;
 private:
     static constexpr std::chrono::milliseconds fade_in_duration = 150ms;
     static constexpr std::chrono::milliseconds fade_out_duration = 300ms;
@@ -74,6 +96,10 @@ private:
     frame_renderer_t frame_renderer = [](auto&, auto&) {};
     std::optional<on_entry_destroy_callback_t> on_entry_destroy_callback;
     std::optional<add_callback_t> add_callback;
+    std::optional<label_decorator_t> label_decorator;
+    std::optional<entry_highlight_t> entry_highlight;
+    std::optional<entry_overlay_t> entry_overlay;
+    std::optional<entry_text_reserve_t> entry_text_reserve;
 
     std::vector<entry_t> entries;
     std::string label;
@@ -81,6 +107,10 @@ private:
    
     std::size_t future_entry_index = 0;
     std::size_t current_entry_index = 0;
+
+    /// Index of an entry whose fade-out finished and which must be destroyed after the
+    /// render loop (erasing during iteration would invalidate the loop).
+    std::optional<std::size_t> entry_to_destroy;
 
     float frame_alpha = 1.00;
     std::chrono::steady_clock::time_point time_clicked;
@@ -113,6 +143,10 @@ public:
     /// Remove currently selected entry with fade-out animation.
     auto remove_current_entry_animated() -> void;
 
+    /// Remove the currently selected entry immediately (no fade-out animation). The actual
+    /// erase is deferred to the end of the render loop to stay safe during iteration.
+    auto remove_current_entry() -> void;
+
     /// Set callback for entry destruction.
     ///
     /// @param new_callback[in] Callback function.
@@ -127,16 +161,48 @@ public:
     ///
     /// @param new_frame_renderer[in] Renderer function.
     auto set_frame_renderer(frame_renderer_t new_frame_renderer) -> void;
-    
+
+    /// Set a decorator for entry labels (e.g. to mark the active entry). Does not affect
+    /// the entry identity, only the displayed text.
+    ///
+    /// @param new_decorator[in] Decorator function.
+    auto set_label_decorator(label_decorator_t new_decorator) -> void;
+
+    /// Set a highlight provider for entries (e.g. to color the active entry's button).
+    ///
+    /// @param new_highlight[in] Highlight function.
+    auto set_entry_highlight(entry_highlight_t new_highlight) -> void;
+
+    /// Set an overlay renderer for entries (e.g. to draw a hotkey badge over an entry).
+    ///
+    /// @param new_overlay[in] Overlay function.
+    auto set_entry_overlay(entry_overlay_t new_overlay) -> void;
+
+    /// Set a reserve provider for entry labels (truncate labels to leave room for an overlay
+    /// on the right). When set, entry labels are left-aligned.
+    ///
+    /// @param new_reserve[in] Reserve function.
+    auto set_entry_text_reserve(entry_text_reserve_t new_reserve) -> void;
+
     /// Render submenu interface.
     ///
     /// @param child[in] Valid pointer to the main window.
     auto render_menu(types::not_null<initializer*> child) -> void;
 
-    /// Render currently selected frame.
+    /// Width (in pixels) of the side menu for the given window, so callers can lay the
+    /// menu and the frame out in either order.
     ///
     /// @param child[in] Valid pointer to the main window.
-    auto render_current_frame(types::not_null<initializer*> child) -> void;
+    /// @return          Side menu width in pixels.
+    auto get_menu_width(types::not_null<initializer*> child) const -> float;
+
+    /// Render currently selected frame.
+    ///
+    /// @param child[in]       Valid pointer to the main window.
+    /// @param frame_width[in] Explicit width for the frame, or 0 to fill the remaining space.
+    ///                        Pass an explicit width when the menu is drawn after the frame,
+    ///                        so the frame does not consume the menu's space.
+    auto render_current_frame(types::not_null<initializer*> child, float frame_width = 0.0f) -> void;
 
     /// Construct submenu.
     ///

--- a/include/plugin/gui/windows/main/widgets/submenu.h
+++ b/include/plugin/gui/windows/main/widgets/submenu.h
@@ -20,6 +20,7 @@
 #define GADMIN_PLUGIN_GUI_WINDOWS_MAIN_WIDGETS_SUBMENU_H
 
 #include "plugin/types/not_null.h"
+#include "plugin/types/color.h"
 #include "plugin/gui/windows/main/initializer.h"
 #include <string>
 #include <any>
@@ -54,9 +55,10 @@ public:
     using label_decorator_t = std::function<std::string(std::size_t index, const std::string& label)>;
 
     /// Callback type for highlighting an entry by overriding its button background color
-    /// (e.g. to mark the active entry). Receives the entry index, returns a packed ImU32
-    /// color, or std::nullopt to keep the default button color.
-    using entry_highlight_t = std::function<std::optional<std::uint32_t>(std::size_t index)>;
+    /// (e.g. to mark the active entry). Receives the entry index, returns the button
+    /// background color, or a default-constructed (transparent, value 0) color to keep
+    /// the default button color.
+    using entry_highlight_t = std::function<types::color(std::size_t index)>;
 
     /// Callback type for drawing extra content over an entry after its button is rendered
     /// (e.g. a small hotkey badge). Receives the entry index and the button's screen-space

--- a/include/plugin/misc/features/me_to_id.h
+++ b/include/plugin/misc/features/me_to_id.h
@@ -30,12 +30,12 @@ namespace plugin::misc::features {
 /// Only the first argument after the command name is checked, so the
 /// `/me` roleplay command and `me` words inside messages are left intact.
 /// Only works if a feature is enabled.
-class me_to_id : public feature {
+class me_to_id final : public feature {
 private:
     auto on_send_command(const samp::out_event<samp::event_id::send_command>& event) const -> bool;
 public:
     auto on_event(const samp::event_info& event) -> bool override;
-}; // class me_to_id : public feature
+}; // class me_to_id final : public feature
 
 } // namespace plugin::misc::features
 

--- a/include/plugin/misc/features/me_to_id.h
+++ b/include/plugin/misc/features/me_to_id.h
@@ -1,0 +1,42 @@
+/// GAdmin - Plugin simplifying the work of administrators on the Gambit-RP
+/// Copyright (C) 2023-2026 The Contributors.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program. If not, see <https://www.gnu.org/licenses/>.
+///
+/// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef GADMIN_PLUGIN_MISC_FEATURES_ME_TO_ID_H
+#define GADMIN_PLUGIN_MISC_FEATURES_ME_TO_ID_H
+
+#include "plugin/misc/base/feature.h"
+#include "plugin/samp/events/send_command.h" // IWYU pragma: keep
+
+namespace plugin::misc::features {
+
+/// Represents a feature that replaces the first command argument `me`
+/// with the local player's server ID (e.g. `/aheal me` -> `/aheal 14`).
+///
+/// Only the first argument after the command name is checked, so the
+/// `/me` roleplay command and `me` words inside messages are left intact.
+/// Only works if a feature is enabled.
+class me_to_id : public feature {
+private:
+    auto on_send_command(const samp::out_event<samp::event_id::send_command>& event) const -> bool;
+public:
+    auto on_event(const samp::event_info& event) -> bool override;
+}; // class me_to_id : public feature
+
+} // namespace plugin::misc::features
+
+#endif // GADMIN_PLUGIN_MISC_FEATURES_ME_TO_ID_H

--- a/src/plugin/gui/hotkey.cpp
+++ b/src/plugin/gui/hotkey.cpp
@@ -62,6 +62,25 @@ auto plugin::gui::key_bind::to_string() const -> std::string {
     return result;
 }
 
+auto plugin::gui::hotkey::saved_binds() -> nlohmann::json& {
+    return external_storage ? *external_storage : (*configuration)["internal"]["hotkeys"];
+}
+
+auto plugin::gui::hotkey::bind_to_external(nlohmann::json* storage) -> hotkey& {
+    external_storage = storage;
+
+    if (storage && storage->contains(label))
+        bind = key_bind(storage->at(label).get<std::uint32_t>());
+    else
+        bind = {};
+
+    return *this;
+}
+
+auto plugin::gui::hotkey::set_external_storage(nlohmann::json* storage) -> void {
+    external_storage = storage;
+}
+
 auto plugin::gui::hotkey::truncate_text_in_button(float button_width, const std::string_view& text) const -> std::string {
     std::string output(text);
     std::string ellipsis = " ...";
@@ -84,6 +103,11 @@ auto plugin::gui::hotkey::truncate_text_in_button(float button_width, const std:
     return output;
 }
 
+auto plugin::gui::hotkey::open_conditions_popup() -> void {
+    if (!handler->changing_any_hotkey && !handler->changing_any_properties)
+        hint_active = handler->changing_any_properties = true;
+}
+
 auto plugin::gui::hotkey::hint_condition() -> bool {
     if (ImGui::IsMouseReleased(ImGuiMouseButton_Right) && ImGui::IsItemHovered() &&
         !handler->changing_any_hotkey && !handler->changing_any_properties)
@@ -102,7 +126,7 @@ auto plugin::gui::hotkey::hint_renderer() -> void {
         hint_active = handler->changing_any_properties = false;
     }
     
-    auto& saved_hotkeys = (*configuration)["internal"]["hotkeys"];
+    auto& saved_hotkeys = saved_binds();
 
     ImFont* bold_font = handler->child->fonts->bold;
     ImFont* regular_font = handler->child->fonts->regular;
@@ -156,7 +180,7 @@ auto plugin::gui::hotkey::hint_renderer() -> void {
 
 auto plugin::gui::hotkey::render(const ImVec2& size) -> void {
     auto now = std::chrono::steady_clock::now();
-    auto& saved_hotkeys = (*configuration)["internal"]["hotkeys"];
+    auto& saved_hotkeys = saved_binds();
 
     widgets::button button(bind.to_string(), label, size);
 

--- a/src/plugin/gui/widgets/button.cpp
+++ b/src/plugin/gui/widgets/button.cpp
@@ -90,8 +90,12 @@ auto plugin::gui::widgets::button::render() -> bool {
     if (!text.empty()) {
         ImVec2 text_size = ImGui::CalcTextSize(text.c_str());
         ImVec2 text_align = ImGui::GetStyle().ButtonTextAlign;
-        ImVec2 text_pos = { start.x + ((size.x - text_size.x) * text_align.x),
-                            start.y + ((size.y - text_size.y) * text_align.y) };
+        ImVec2 frame_padding = ImGui::GetStyle().FramePadding;
+
+        // Инсет текста на FramePadding: для центрированных кнопок результат не меняется,
+        // а при выравнивании влево/вправо текст не прилипает к краю кнопки.
+        ImVec2 text_pos = { start.x + frame_padding.x + ((size.x - text_size.x - frame_padding.x * 2) * text_align.x),
+                            start.y + frame_padding.y + ((size.y - text_size.y - frame_padding.y * 2) * text_align.y) };
 
         draw_list->AddText(text_pos, ImGui::GetColorU32(ImGuiCol_Text), text.c_str());
     }

--- a/src/plugin/gui/widgets/button.cpp
+++ b/src/plugin/gui/widgets/button.cpp
@@ -49,7 +49,7 @@ auto plugin::gui::widgets::button::render() -> bool {
 
     it.border_alpha = animation::bring_to(it.border_alpha, (it.hovered.state) ? 255 : 0, it.hovered.time, durations[0]);
 
-    if (it.click_position.has_value()) {
+    if (draw_click_animation && it.click_position.has_value()) {
         ImVec2 clip_rect_min = { start.x + border_size, start.y + border_size };
         ImVec2 clip_rect_max = { end.x - border_size, end.y - border_size };
 
@@ -92,8 +92,8 @@ auto plugin::gui::widgets::button::render() -> bool {
         ImVec2 text_align = ImGui::GetStyle().ButtonTextAlign;
         ImVec2 frame_padding = ImGui::GetStyle().FramePadding;
 
-        // Инсет текста на FramePadding: для центрированных кнопок результат не меняется,
-        // а при выравнивании влево/вправо текст не прилипает к краю кнопки.
+        // Inset the text by FramePadding: for centered buttons the result is unchanged,
+        // while for left/right alignment the text no longer sticks to the button edge.
         ImVec2 text_pos = { start.x + frame_padding.x + ((size.x - text_size.x - frame_padding.x * 2) * text_align.x),
                             start.y + frame_padding.y + ((size.y - text_size.y - frame_padding.y * 2) * text_align.y) };
 
@@ -103,9 +103,12 @@ auto plugin::gui::widgets::button::render() -> bool {
     bool result = false;
 
     if (ImGui::InvisibleButton((text + "##" + id).c_str(), size)) {
-        it.radius = 0;
-        it.click_time = std::chrono::steady_clock::now();
-        it.click_position = ImGui::GetMousePos();
+        if (draw_click_animation) {
+            it.radius = 0;
+            it.click_time = std::chrono::steady_clock::now();
+            it.click_position = ImGui::GetMousePos();
+        }
+
         result = true;
     }
 

--- a/src/plugin/gui/windows/interaction_area.cpp
+++ b/src/plugin/gui/windows/interaction_area.cpp
@@ -42,8 +42,11 @@ auto plugin::gui::windows::interaction_area::find_player_nearby_to_screen_center
     auto [ size_x, size_y ] = game::get_screen_resolution();
     std::optional<search_result> result;
 
+    bool ignore_spectated = (*configuration)["windows"]["interaction_area"]["ignore_spectated_target"];
+
     for (const auto& [ player, ped ] : samp::player::get_stream_players()) {
-        if (player.id == samp::user::get_id() || (server::spectator::is_active() && player.id == server::spectator::id))
+        if (player.id == samp::user::get_id()
+            || (ignore_spectated && server::spectator::is_active() && player.id == server::spectator::id))
             continue;
 
         game::ped game_ped = ped.get_game_ped();
@@ -85,15 +88,34 @@ auto plugin::gui::windows::interaction_area::find_vehicle_nearby_to_screen_cente
 
     game::vehicle player_vehicle = game::ped::get_player().get_vehicle();
 
+    std::optional<game::vehicle> spectated_vehicle;
+    if ((*configuration)["windows"]["interaction_area"]["ignore_spectated_target"]
+        && server::spectator::is_active())
+    {
+        for (const auto& [ player, ped ] : samp::player::get_stream_players()) {
+            if (player.id != server::spectator::id)
+                continue;
+
+            if (game::ped spectated_ped = ped.get_game_ped()) {
+                if (game::vehicle occupied = spectated_ped.get_vehicle())
+                    spectated_vehicle = occupied;
+            }
+
+            break;
+        }
+    }
+
     for (std::uint16_t id = 0; id < samp::vehicle_pool::max_vehicles; id++) {
         auto vehicle = samp::vehicle_pool::get_vehicle(id);
-        
+
         if (!vehicle)
             continue;
 
         game::vehicle game_vehicle = vehicle->get_game_vehicle();
-        
-        if (!game_vehicle || !game_vehicle.is_on_screen() || (player_vehicle && game_vehicle == player_vehicle))
+
+        if (!game_vehicle || !game_vehicle.is_on_screen()
+            || (player_vehicle && game_vehicle == player_vehicle)
+            || (spectated_vehicle && game_vehicle == *spectated_vehicle))
             continue;
 
         types::vector_3d screen_point = game::convert_3d_coords_to_screen(game_vehicle.get_position());
@@ -136,6 +158,12 @@ auto plugin::gui::windows::interaction_area::handle_controls() -> void {
     if (ImGui::IsKeyReleased(ImGuiKey_1))
         current_search_type = (current_search_type == search_type::vehicles)
             ? search_type::players : search_type::vehicles;
+
+    if (ImGui::IsKeyReleased(ImGuiKey_0)) {
+        bool& ignore_spectated = (*configuration)["windows"]["interaction_area"]["ignore_spectated_target"].get_ref<bool&>();
+        ignore_spectated = !ignore_spectated;
+        configuration->save();
+    }
 
     for (int action_id = 0; action_id < action_count_per_type; action_id++) {
         if (ImGui::IsKeyReleased(static_cast<ImGuiKey>(ImGuiKey_2 + action_id))) {
@@ -216,6 +244,9 @@ auto plugin::gui::windows::interaction_area::render_help_text(ImDrawList* draw_l
 auto plugin::gui::windows::interaction_area::render_search_description(ImDrawList* draw_list, float radius, const types::color& active_color,
                                                                        const std::string& search_description) const -> void
 {
+    bool ignore_spectated = (*configuration)["windows"]["interaction_area"]["ignore_spectated_target"];
+    std::string ignore_line = std::format("0 - не наводиться на объект слежки: {}", ignore_spectated ? "Вкл" : "Выкл");
+
     std::array<std::string, 2> lines = { "1 - переключение между режимами (поиск игроков или машин)",
                                          search_description };
 
@@ -229,6 +260,11 @@ auto plugin::gui::windows::interaction_area::render_search_description(ImDrawLis
 
         render_stroked_text(draw_list, font, { x, y }, active_color, line.c_str());
     }
+
+    float ignore_x = center.x - regular_font->CalcTextSizeA(fonts_size, FLT_MAX, 0.0f, ignore_line.c_str()).x / 2;
+    float ignore_y = center.y + radius + 20 + fonts_size;
+
+    render_stroked_text(draw_list, regular_font, { ignore_x, ignore_y }, active_color, ignore_line.c_str());
 }
 
 auto plugin::gui::windows::interaction_area::render() -> void {

--- a/src/plugin/gui/windows/interaction_area.cpp
+++ b/src/plugin/gui/windows/interaction_area.cpp
@@ -160,9 +160,8 @@ auto plugin::gui::windows::interaction_area::handle_controls() -> void {
             ? search_type::players : search_type::vehicles;
 
     if (ImGui::IsKeyReleased(ImGuiKey_0)) {
-        bool& ignore_spectated = (*configuration)["windows"]["interaction_area"]["ignore_spectated_target"].get_ref<bool&>();
-        ignore_spectated = !ignore_spectated;
-        configuration->save();
+        auto& window_configuration = (*configuration)["windows"]["interaction_area"];
+        window_configuration["ignore_spectated_target"].get_ref<bool&>() ^= true;
     }
 
     for (int action_id = 0; action_id < action_count_per_type; action_id++) {

--- a/src/plugin/gui/windows/main/frames/presets.cpp
+++ b/src/plugin/gui/windows/main/frames/presets.cpp
@@ -252,7 +252,7 @@ auto plugin::gui::windows::main::frames::presets::ensure_preset_ids() -> void {
 }
 
 auto plugin::gui::windows::main::frames::presets::preset_hotkey_label(int id) -> std::string {
-    return "preset:" + std::to_string(id);
+    return "##preset:" + std::to_string(id);
 }
 
 auto plugin::gui::windows::main::frames::presets::register_preset_hotkey(int id) -> void {
@@ -430,8 +430,6 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
                 ImGui::SameLine();
             }
 
-            ImGui::AlignTextToFramePadding();
-
             if (gui::widgets::text_button(name + "##presets_sub:" + id).render())
                 open_subsection_popup(section, item, name, meta_item, settings);
 
@@ -449,7 +447,6 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
         }
 
         // No other types exist at the section top level, but show the name just in case.
-        ImGui::AlignTextToFramePadding();
         gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
     }
 }
@@ -606,7 +603,7 @@ auto plugin::gui::windows::main::frames::presets::render_player_checker_body(nlo
     ImGui::InputTextWithHint("##presets_pc_nick", "Никнейм игрока", &pc_nickname_input);
     ImGui::SameLine();
 
-    if (gui::widgets::button("Добавить##presets_pc_add", { add_button_width, buttons_height }).render()
+    if (gui::widgets::button("Добавить##presets_pc_add", { add_button_width, ImGui::GetFrameHeight() }).render()
         && !pc_nickname_input.empty())
     {
         players.push_back({ { "nickname", pc_nickname_input }, { "description", "" } });
@@ -652,8 +649,6 @@ auto plugin::gui::windows::main::frames::presets::frame_renderer(std::string& la
             gui::widgets::hint::render_as_guide("ЛКМ — задать клавишу, ПКМ — условия активации");
         }
 
-        ImGui::Separator();
-
         // The bordered settings editor fills the middle, leaving room for the stacked action
         // footer below (three full-width buttons + the spacing between them).
         float spacing = ImGui::GetStyle().ItemSpacing.y;
@@ -684,7 +679,7 @@ auto plugin::gui::windows::main::frames::presets::frame_renderer(std::string& la
 
         if (gui::widgets::button("Удалить##frames::presets-delete-" + index, button_size)
                 .without_click_animation().render())
-            submenu.remove_current_entry();
+            submenu.remove_current_entry_animated();
     }
     ImGui::PopFont();
 }

--- a/src/plugin/gui/windows/main/frames/presets.cpp
+++ b/src/plugin/gui/windows/main/frames/presets.cpp
@@ -1,0 +1,997 @@
+/// GAdmin - Plugin simplifying the work of administrators on the Gambit-RP
+/// Copyright (C) 2023-2026 The Contributors.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// SPDX-License-Identifier: GPL-3.0-only
+
+#include "plugin/gui/windows/main/frames/presets.h"
+#include "plugin/gui/widgets/button.h"
+#include "plugin/gui/widgets/hint.h"
+#include "plugin/gui/widgets/search.h"
+#include "plugin/gui/widgets/text.h"
+#include "plugin/gui/widgets/text_button.h"
+#include "plugin/gui/widgets/toggle_button.h"
+#include "plugin/gui/windows/main/base/custom_setting.h"
+#include "plugin/gui/windows/main/custom_settings/message_recolorer.h"
+#include "plugin/gui/windows/main/custom_settings/report.h"
+#include "plugin/gui/windows/main/custom_settings/short_commands.h"
+#include "plugin/gui/windows/main/custom_settings/spectator_actions.h"
+#include "plugin/gui/windows/main/custom_settings/spectator_information.h"
+#include "plugin/gui/style.h"
+#include "plugin/gui/icon.h"
+#include "plugin/gui/notify.h"
+#include "plugin/types/color.h"
+#include "plugin/plugin.h"
+#include "plugin/log.h"
+#include "common/common.h"
+#include <misc/cpp/imgui_stdlib.h>
+#include <algorithm>
+#include <array>
+#include <fstream>
+#include <utility>
+
+static constexpr std::uint8_t options_bytes[] = {
+
+#ifdef USE_EMBEDDED_MESSAGE_PACK
+#embed "../../../../../../embed/main_frame_settings.mpk"
+#else
+#embed "../../../../../../embed/main_frame_settings.json"
+#endif // USE_EMBEDDED_MESSAGE_PACK
+
+}; // static constexpr std::uint8_t options_bytes[]
+
+auto plugin::gui::windows::main::frames::presets::load_presets() -> void {
+    preset_list = nlohmann::json::array();
+
+    if (!std::filesystem::exists(presets_file))
+        return;
+
+    std::ifstream file(presets_file);
+
+    if (!file) {
+        log::error("presets: failed to open \"{}\"", presets_file.string());
+        return;
+    }
+
+    try {
+        nlohmann::json parsed = nlohmann::json::parse(file);
+
+        if (parsed.is_array())
+            preset_list = std::move(parsed);
+        else
+            log::error("presets: \"{}\" is not a JSON array; ignored", presets_file.string());
+    } catch (const std::exception& e) {
+        log::error("presets: failed to parse \"{}\": {}", presets_file.string(), e.what());
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::save_presets() const -> void {
+    std::ofstream file(presets_file, std::ios::out | std::ios::trunc);
+
+    if (!file) {
+        log::error("presets: failed to write \"{}\"", presets_file.string());
+        return;
+    }
+
+    file << preset_list.dump(4);
+}
+
+auto plugin::gui::windows::main::frames::presets::is_secret(const std::string& section, const std::string& item) -> bool {
+    return section == "misc" && item == "auto_login";
+}
+
+auto plugin::gui::windows::main::frames::presets::snapshot_item(const std::string& section, const std::string& item) const
+    -> nlohmann::json
+{
+    return (*configuration)[section][item];
+}
+
+auto plugin::gui::windows::main::frames::presets::capture_all() const -> nlohmann::json {
+    nlohmann::json settings = nlohmann::json::object();
+
+    for (const auto& [ section, meta_section ] : options.items())
+        for (const auto& [ item, meta_item ] : meta_section.items()) {
+            if (item.starts_with('_') || is_secret(section, item))
+                continue;
+
+            settings[section][item] = snapshot_item(section, item);
+        }
+
+    settings["hotkeys"] = capture_hotkeys();
+    settings["player_checker"] = capture_player_checker();
+
+    return settings;
+}
+
+auto plugin::gui::windows::main::frames::presets::capture_hotkeys() const -> nlohmann::json {
+    nlohmann::json result = nlohmann::json::object();
+
+    for (gui::hotkey& pooled : child->child->hotkey_handler->pool)
+        if (pooled.can_render_in_settings())
+            result[pooled.label] = pooled.bind.join();
+
+    return result;
+}
+
+auto plugin::gui::windows::main::frames::presets::capture_player_checker() const -> nlohmann::json {
+    nlohmann::json& windows = (*configuration)["windows"];
+
+    if (windows.contains("player_checker") && windows["player_checker"].contains("players")
+        && windows["player_checker"]["players"].is_array())
+        return windows["player_checker"]["players"];
+
+    return nlohmann::json::array();
+}
+
+auto plugin::gui::windows::main::frames::presets::refresh_values(nlohmann::json& preset) const -> void {
+    if (!preset.contains("settings"))
+        return;
+
+    for (auto& [ section, items ] : preset["settings"].items()) {
+        // Спец-блоки (хоткеи, чекер) живут не как одноимённые секции конфига — обновляем их отдельно.
+        if (section == "hotkeys" || section == "player_checker")
+            continue;
+
+        nlohmann::json& live_section = (*configuration)[section];
+
+        for (auto& [ item, value ] : items.items())
+            if (live_section.contains(item))
+                value = live_section[item];
+    }
+
+    if (preset["settings"].contains("hotkeys"))
+        preset["settings"]["hotkeys"] = capture_hotkeys();
+
+    if (preset["settings"].contains("player_checker"))
+        preset["settings"]["player_checker"] = capture_player_checker();
+}
+
+auto plugin::gui::windows::main::frames::presets::apply_preset(const nlohmann::json& preset) const -> void {
+    if (!preset.contains("settings"))
+        return;
+
+    const nlohmann::json& settings = preset["settings"];
+
+    // merge_patch посекционно: ключи, которых в пресете нет (исключённые элементы, пароли,
+    // более новые настройки), остаются в живом конфиге нетронутыми.
+    for (types::zstring_t section : captured_sections)
+        if (settings.contains(section))
+            (*configuration)[section].merge_patch(settings.at(section));
+
+    // Спец-блоки: список чекера и хоткеи лежат по своим путям, применяем их явно.
+    if (settings.contains("player_checker"))
+        (*configuration)["windows"]["player_checker"]["players"] = settings.at("player_checker");
+
+    if (settings.contains("hotkeys") && settings.at("hotkeys").is_object()) {
+        nlohmann::json& live_hotkeys = (*configuration)["internal"]["hotkeys"];
+
+        for (const auto& [ label, packed ] : settings.at("hotkeys").items()) {
+            live_hotkeys[label] = packed;
+
+            // Обновляем живой объект хоткея, чтобы бинд применился сразу, без перезапуска.
+            if (gui::hotkey* pooled = find_pool_hotkey(label))
+                pooled->bind = gui::key_bind(packed.get<std::uint32_t>());
+        }
+    }
+
+    configuration->save();
+}
+
+auto plugin::gui::windows::main::frames::presets::get_active_index() const -> int {
+    return (*configuration)["internal"].value("active_preset", -1);
+}
+
+auto plugin::gui::windows::main::frames::presets::set_active_index(int index) const -> void {
+    (*configuration)["internal"]["active_preset"] = index;
+    configuration->save();
+}
+
+auto plugin::gui::windows::main::frames::presets::preset_matches_live(const nlohmann::json& preset) const -> bool {
+    if (!preset.contains("settings") || preset["settings"].empty())
+        return false;
+
+    for (const auto& [ section, items ] : preset["settings"].items()) {
+        // Хоткеи и список чекера не участвуют в сравнении (их сопоставление сложнее
+        // и не влияет на маркер «применён/изменён»).
+        if (section == "hotkeys" || section == "player_checker")
+            continue;
+
+        nlohmann::json& live_section = (*configuration)[section];
+
+        for (const auto& [ item, value ] : items.items())
+            if (!live_section.contains(item) || live_section[item] != value)
+                return false;
+    }
+
+    return true;
+}
+
+auto plugin::gui::windows::main::frames::presets::render_status_banner(const nlohmann::json& preset, std::size_t index) const
+    -> void
+{
+    bool active = static_cast<int>(index) == get_active_index();
+    bool matches = active && preset_matches_live(preset);
+
+    style::accent_colors_t& accents = style::get_current_accent_colors();
+
+    ImU32 color;
+    types::zstring_t glyph;
+    types::zstring_t text;
+
+    if (active && matches) {
+        color = *accents.green;
+        glyph = ICON_CHECK;
+        text  = "Применён";
+    } else if (active) {
+        color = *accents.yellow;
+        glyph = ICON_FLAG;
+        text  = "Применён, но настройки изменены вручную";
+    } else {
+        color = ImGui::GetColorU32(ImGuiCol_TextDisabled);
+        glyph = ICON_CIRCLE;
+        text  = "Не применён";
+    }
+
+    // Иконку рисуем шрифтом `icon` (в regular её глифов нет — иначе «?»), текст — обычным.
+    ImVec2 pos = ImGui::GetCursorScreenPos();
+    float line_height = ImGui::GetTextLineHeight();
+    ImVec2 glyph_size = icon_font->CalcTextSizeA(common_font_size, FLT_MAX, 0.0f, glyph);
+
+    ImGui::GetWindowDrawList()->AddText(icon_font, common_font_size,
+                                        { pos.x, pos.y + (line_height - glyph_size.y) / 2.0f }, color, glyph);
+
+    ImGui::Dummy({ glyph_size.x + ImGui::GetStyle().ItemSpacing.x, line_height });
+    ImGui::SameLine();
+    ImGui::TextColored(ImGui::ColorConvertU32ToFloat4(color), "%s", text);
+}
+
+auto plugin::gui::windows::main::frames::presets::ensure_preset_ids() -> void {
+    int max_id = 0;
+
+    for (auto& preset : preset_list)
+        if (preset.contains("id") && preset["id"].is_number_integer())
+            max_id = std::max(max_id, preset["id"].get<int>());
+
+    bool changed = false;
+
+    for (auto& preset : preset_list)
+        if (!preset.contains("id") || !preset["id"].is_number_integer()) {
+            preset["id"] = ++max_id;
+            changed = true;
+        }
+
+    next_id = max_id + 1;
+
+    if (changed)
+        save_presets();
+}
+
+auto plugin::gui::windows::main::frames::presets::preset_hotkey_label(int id) -> std::string {
+    return "preset:" + std::to_string(id);
+}
+
+auto plugin::gui::windows::main::frames::presets::register_preset_hotkey(int id) -> void {
+    gui::hotkey preset_hotkey(preset_hotkey_label(id), gui::key_bind());
+
+    preset_hotkey.without_rendering_in_settings();
+    preset_hotkey.with_callback([this, id](gui::hotkey&) { apply_preset_by_id(id); });
+
+    child->child->hotkey_handler->add(preset_hotkey);
+}
+
+auto plugin::gui::windows::main::frames::presets::find_pool_hotkey(const std::string& label) const -> gui::hotkey* {
+    for (gui::hotkey& pooled : child->child->hotkey_handler->pool)
+        if (pooled.label == label)
+            return &pooled;
+
+    return nullptr;
+}
+
+auto plugin::gui::windows::main::frames::presets::entry_hotkey_text(std::size_t index)
+    -> std::optional<std::string>
+{
+    if (index >= preset_list.size())
+        return std::nullopt;
+
+    gui::hotkey* preset_hotkey = find_pool_hotkey(preset_hotkey_label(preset_list[index].value("id", -1)));
+
+    if (!preset_hotkey || preset_hotkey->bind.empty())
+        return std::nullopt;
+
+    return preset_hotkey->bind.to_string();
+}
+
+auto plugin::gui::windows::main::frames::presets::apply_preset_by_id(int id) -> void {
+    for (std::size_t index = 0; index < preset_list.size(); index++)
+        if (preset_list[index].value("id", -1) == id) {
+            apply_preset(preset_list[index]);
+            set_active_index(static_cast<int>(index));
+
+            std::string name = preset_list[index].value("name", std::string("Пресет"));
+            gui::notify::send(gui::notification("Пресет применён", "«" + name + "» — настройки применены.", ICON_CHECK));
+
+            return;
+        }
+}
+
+auto plugin::gui::windows::main::frames::presets::render_editable_name(std::string& frame_label, std::string& value)
+    -> void
+{
+    ImU32 color = ImGui::GetColorU32(ImGuiCol_WindowBg);
+
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, color);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgActive, color);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, color);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, { 0, 0 });
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 0);
+    ImGui::PushFont(bold_font, title_font_size);
+    {
+        if (ImGui::InputText("##preset_name", &value)) {
+            frame_label = value;
+            pending_save = true;
+        }
+    }
+    ImGui::PopFont();
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(3);
+
+    gui::widgets::hint::render_as_guide("Нажмите на имя, чтобы переименовать пресет");
+}
+
+auto plugin::gui::windows::main::frames::presets::render_variant(const std::string& id, nlohmann::ordered_json& config,
+                                                                 nlohmann::json& value) -> void
+{
+    if (!value.is_string())
+        return;
+
+    std::string& setter = value.get_ref<std::string&>();
+    int current = 0;
+
+    for (std::size_t index = 0; index < config.size(); index++)
+        if (config[index][0] == setter) {
+            current = static_cast<int>(index);
+            break;
+        }
+
+    std::string format = config[current][1];
+
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+
+    if (ImGui::SliderInt(id.c_str(), &current, 0, static_cast<int>(config.size()) - 1, format.c_str())) {
+        setter = config[current][0].get<std::string>();
+        pending_save = true;
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::render_color(const std::string& id, nlohmann::json& value) -> void {
+    types::color color = value.get<types::color>();
+    ImVec4 vector_color = ImGui::ColorConvertU32ToFloat4(*color);
+
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+
+    if (ImGui::ColorEdit3(id.c_str(), reinterpret_cast<float*>(&vector_color), ImGuiColorEditFlags_NoInputs)) {
+        value = types::color(ImGui::ColorConvertFloat4ToU32(vector_color));
+        pending_save = true;
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::render_custom(const std::string& custom_id, nlohmann::json& value)
+    -> void
+{
+    static auto custom_settings = std::to_array<custom_setting_ptr_t>({
+        std::make_unique<custom_settings::report>(),
+        std::make_unique<custom_settings::short_commands>(),
+        std::make_unique<custom_settings::spectator_information>(),
+        std::make_unique<custom_settings::spectator_actions>(),
+        std::make_unique<custom_settings::message_recolorer>()
+    }); // static auto custom_settings = std::to_array<custom_setting_ptr_t>({ ... })
+
+    auto setting = std::find_if(custom_settings.begin(), custom_settings.end(),
+        [&custom_id](const custom_setting_ptr_t& setting) { return setting->get_id() == custom_id; });
+
+    if (setting == custom_settings.end()) {
+        log::error("presets::render_custom: custom setting \"{}\" not found", custom_id);
+        return;
+    }
+
+    // У custom-редакторов нет сигнала об изменении — сравниваем дамп до/после (значение небольшое).
+    std::string before = value.dump();
+    (*setting)->render(child->child, value);
+
+    if (value.dump() != before)
+        pending_save = true;
+}
+
+auto plugin::gui::windows::main::frames::presets::render_option(const std::string& id, const std::string& key,
+                                                                const std::string& subsection_key,
+                                                                nlohmann::ordered_json& meta_option, nlohmann::json& parent)
+    -> void
+{
+    if (!parent.contains(key))
+        return;
+
+    item_type type = meta_option["_type"];
+    std::string name = meta_option["_name"];
+    std::string widget_id = "##opt:" + id;
+    nlohmann::json& value = parent[key];
+    float available = ImGui::GetContentRegionAvail().x;
+
+    switch (type) {
+        case item_type::boolean:
+            if (value.is_boolean() && gui::widgets::toggle_button(widget_id, value.get_ref<bool&>()).render())
+                pending_save = true;
+
+            ImGui::SameLine();
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+            break;
+
+        case item_type::int_range: {
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+
+            nlohmann::ordered_json& config = meta_option["_config"];
+            int minimum = config[0].get<int>(), maximum = config[1].get<int>();
+            int current = static_cast<int>(value.get<long long>());
+
+            ImGui::SetNextItemWidth(available);
+
+            if (ImGui::SliderInt(widget_id.c_str(), &current, minimum, maximum)) {
+                value = static_cast<std::uint64_t>(current);
+                pending_save = true;
+            }
+
+            break;
+        }
+
+        case item_type::float_range: {
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+
+            nlohmann::ordered_json& config = meta_option["_config"];
+            double minimum = config[0].get<double>(), maximum = config[1].get<double>();
+            double current = value.get<double>();
+
+            ImGui::SetNextItemWidth(available);
+
+            if (ImGui::SliderScalar(widget_id.c_str(), ImGuiDataType_Double, &current, &minimum, &maximum, "%.3f")) {
+                value = current;
+                pending_save = true;
+            }
+
+            break;
+        }
+
+        case item_type::variant:
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+            render_variant(widget_id, meta_option["_config"], value);
+            break;
+
+        case item_type::color:
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+            render_color(widget_id, value);
+            break;
+
+        case item_type::input:
+            if (auto* setter = value.get_ptr<std::string*>()) {
+                gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+                ImGui::SetNextItemWidth(available);
+
+                if (ImGui::InputText(widget_id.c_str(), setter))
+                    pending_save = true;
+            }
+
+            break;
+
+        case item_type::custom:
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+            render_custom(subsection_key + "." + key, value);
+            break;
+
+        default:
+            break;
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::open_subsection_popup(const std::string& section,
+                                                                        const std::string& item,
+                                                                        const std::string& name,
+                                                                        nlohmann::ordered_json& meta_item,
+                                                                        nlohmann::json& settings) -> void
+{
+    // Захватываем указатели на стабильные узлы: meta_item живёт в `options` (член класса),
+    // а ветка значения — в текущем пресете (не перевыделяется, пока попап открыт).
+    nlohmann::json* value = &settings[section][item];
+    nlohmann::ordered_json* meta = &meta_item;
+    std::string subsection_key = item;
+    std::string title = name;
+
+    popup.set_renderer([this, value, meta, subsection_key, title] {
+        // Имя пресета читаем «вживую» по текущей записи — переименование подхватится сразу.
+        std::size_t current = submenu.get_current_entry_index();
+        std::string preset_name = current < preset_list.size()
+            ? preset_list[current].value("name", std::string("пресет")) : std::string("пресет");
+
+        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetColorU32(ImGuiCol_TextDisabled));
+        gui::widgets::text(regular_font, common_font_size, 0,
+                           "Настройка относится к пресету «{}»", preset_name);
+        ImGui::PopStyleColor();
+
+        gui::widgets::text(bold_font, title_font_size, 0, "{}", title);
+
+        ImGui::PushFont(regular_font, common_font_size);
+        {
+            // `use` редактируется тумблером в строке списка, поэтому в попапе только опции.
+            for (auto& [ key, meta_option ] : meta->items()) {
+                if (key.starts_with('_'))
+                    continue;
+
+                render_option(subsection_key + ":" + key, key, subsection_key, meta_option, *value);
+            }
+        }
+        ImGui::PopFont();
+    });
+
+    popup.open();
+}
+
+auto plugin::gui::windows::main::frames::presets::render_section_editor(const std::string& section,
+                                                                        nlohmann::ordered_json& meta_section,
+                                                                        nlohmann::json& settings) -> void
+{
+    std::string section_name = meta_section["_name"];
+
+    // При активном поиске пропускаем разделы без совпадений и форсируем раскрытие остальных.
+    if (!editor_search.empty()) {
+        bool any_match = false;
+
+        for (auto& [ item, meta_item ] : meta_section.items())
+            if (!item.starts_with('_') && !is_secret(section, item)
+                && editor_search.contains(meta_item["_name"].get<std::string>()))
+            {
+                any_match = true;
+                break;
+            }
+
+        if (!any_match)
+            return;
+
+        ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    }
+
+    if (!ImGui::CollapsingHeader((section_name + "##presets_sec:" + section).c_str()))
+        return;
+
+    for (auto& [ item, meta_item ] : meta_section.items()) {
+        if (item.starts_with('_') || is_secret(section, item))
+            continue;
+
+        item_type type = meta_item["_type"];
+        std::string name = meta_item["_name"];
+
+        if (!editor_search.contains(name))
+            continue;
+
+        std::string id = section + ":" + item;
+
+        // Пресет — полный снимок настроек. Если значения ещё нет (старый пресет или
+        // настройка, добавленная позже), берём актуальное из живого конфига.
+        if (!settings.contains(section) || !settings[section].contains(item)) {
+            include_item(section, item, settings);
+            pending_save = true;
+        }
+
+        nlohmann::json& value = settings[section][item];
+
+        // Подсекция: тумблер `use` + кликабельное имя, открывающее детальный попап — ровно как в «Настройках».
+        if (type == item_type::subsection) {
+            if (value.contains("use") && value["use"].is_boolean()) {
+                if (gui::widgets::toggle_button("##use:" + id, value["use"].get_ref<bool&>()).render())
+                    pending_save = true;
+
+                ImGui::SameLine();
+            }
+
+            ImGui::AlignTextToFramePadding();
+
+            if (gui::widgets::text_button(name + "##presets_sub:" + id).render())
+                open_subsection_popup(section, item, name, meta_item, settings);
+
+            continue;
+        }
+
+        // Bool-функция: тумблер значения + имя.
+        if (type == item_type::boolean && value.is_boolean()) {
+            if (gui::widgets::toggle_button("##val:" + id, value.get_ref<bool&>()).render())
+                pending_save = true;
+
+            ImGui::SameLine();
+            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+            continue;
+        }
+
+        // На верхнем уровне секции иных типов нет, но на всякий случай покажем имя.
+        ImGui::AlignTextToFramePadding();
+        gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::include_item(const std::string& section, const std::string& item,
+                                                               nlohmann::json& settings) const -> void
+{
+    settings[section][item] = snapshot_item(section, item);
+}
+
+auto plugin::gui::windows::main::frames::presets::render_editor(nlohmann::json& preset) -> void {
+    if (!preset.contains("settings") || !preset["settings"].is_object())
+        preset["settings"] = nlohmann::json::object();
+
+    nlohmann::json& settings = preset["settings"];
+    int preset_id = preset.value("id", -1);
+
+    gui::widgets::text(bold_font, common_font_size, 0, "Настройки пресета");
+
+    float full_width = ImGui::GetContentRegionAvail().x;
+
+    editor_search.render(full_width, "Поиск функции по названию...");
+
+    ImGui::BeginChild("presets::editor", { 0, 0 }, ImGuiChildFlags_Borders);
+    {
+        ImGui::PushFont(regular_font, common_font_size);
+        {
+            for (auto& [ section, meta_section ] : options.items())
+                render_section_editor(section, meta_section, settings);
+
+            render_hotkeys_section(settings, preset_id);
+            render_player_checker_section(settings);
+        }
+        ImGui::PopFont();
+    }
+    ImGui::EndChild();
+}
+
+auto plugin::gui::windows::main::frames::presets::ensure_hotkey_editors(nlohmann::json& hotkeys, int preset_id) -> void {
+    if (preset_id == hotkey_editors_preset_id)
+        return;
+
+    hotkey_editors.clear();
+    gui::hotkey_handler* handler = child->child->hotkey_handler.get();
+
+    for (gui::hotkey& pooled : handler->pool) {
+        if (!pooled.can_render_in_settings())
+            continue;
+
+        gui::hotkey editor(pooled.label, gui::key_bind());
+
+        editor.without_rendering_in_settings().with_handler(handler).bind_to_external(&hotkeys);
+        hotkey_editors.push_back(std::move(editor));
+    }
+
+    hotkey_editors_preset_id = preset_id;
+}
+
+auto plugin::gui::windows::main::frames::presets::render_hotkeys_section(nlohmann::json& settings, int preset_id)
+    -> void
+{
+    if (!settings.contains("hotkeys") || !settings["hotkeys"].is_object()) {
+        settings["hotkeys"] = capture_hotkeys();
+        pending_save = true;
+    }
+
+    nlohmann::json& hotkeys = settings["hotkeys"];
+    ensure_hotkey_editors(hotkeys, preset_id);
+
+    // Каждый кадр освежаем указатель на хранилище: preset_list (json-массив) может
+    // перевыделиться при добавлении пресета, и закэшированный в редакторах указатель
+    // на settings["hotkeys"] стал бы висячим (use-after-free).
+    for (gui::hotkey& editor : hotkey_editors)
+        editor.set_external_storage(&hotkeys);
+
+    // При активном поиске показываем секцию только если есть совпадения по меткам хоткеев.
+    if (!editor_search.empty()) {
+        bool any_match = false;
+
+        for (gui::hotkey& editor : hotkey_editors)
+            if (editor_search.contains(editor.label)) {
+                any_match = true;
+                break;
+            }
+
+        if (!any_match)
+            return;
+
+        ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    }
+
+    if (!ImGui::CollapsingHeader("Горячие клавиши##presets_sec:hotkeys"))
+        return;
+
+    gui::widgets::hint::render_as_guide("ЛКМ — задать клавишу, ПКМ — условия активации (в слежке, на /alogin и т.д.).");
+
+    // Хоткей-виджет пишет бинд прямо в JSON пресета через внешнее хранилище. Сравниваем
+    // дамп до/после, чтобы отметить пресет на сохранение при любом изменении.
+    std::string before = hotkeys.dump();
+
+    for (gui::hotkey& editor : hotkey_editors) {
+        if (!editor_search.contains(editor.label))
+            continue;
+
+        editor.render({ 160.0f, buttons_height });
+        ImGui::SameLine();
+        ImGui::AlignTextToFramePadding();
+
+        // Подпись — кликабельный текст (с подсветкой при наведении, как в других вкладках):
+        // ЛКМ открывает тот же попап условий активации, что и ПКМ по кнопке клавиши.
+        if (gui::widgets::text_button(editor.label).render())
+            editor.open_conditions_popup();
+    }
+
+    if (hotkeys.dump() != before)
+        pending_save = true;
+}
+
+auto plugin::gui::windows::main::frames::presets::render_player_checker_section(nlohmann::json& settings) -> void {
+    if (!settings.contains("player_checker") || !settings["player_checker"].is_array()) {
+        settings["player_checker"] = capture_player_checker();
+        pending_save = true;
+    }
+
+    // Список игроков — отдельная сущность, под фильтр функций не подводим.
+    if (!editor_search.empty())
+        return;
+
+    if (!ImGui::CollapsingHeader("Чекер игроков##presets_sec:player_checker"))
+        return;
+
+    render_player_checker_body(settings["player_checker"]);
+}
+
+auto plugin::gui::windows::main::frames::presets::render_player_checker_body(nlohmann::json& players) -> void {
+    ImGui::BeginChild("presets::pc_list", { 0, 120 }, ImGuiChildFlags_Borders);
+    {
+        for (std::size_t i = 0; i < players.size(); i++) {
+            std::string nickname = players[i].value("nickname", std::string());
+
+            if (ImGui::Selectable((nickname + "##presets_pc:" + std::to_string(i)).c_str(), pc_selected_index == i)) {
+                pc_selected_index = i;
+                pc_description_input = players[i].value("description", std::string());
+            }
+        }
+    }
+    ImGui::EndChild();
+
+    float full_width = ImGui::GetContentRegionAvail().x;
+    float add_button_width = 140.0f;
+
+    ImGui::SetNextItemWidth(full_width - add_button_width - ImGui::GetStyle().ItemSpacing.x);
+    ImGui::InputTextWithHint("##presets_pc_nick", "Никнейм игрока", &pc_nickname_input);
+    ImGui::SameLine();
+
+    if (gui::widgets::button("Добавить##presets_pc_add", { add_button_width, buttons_height }).render()
+        && !pc_nickname_input.empty())
+    {
+        players.push_back({ { "nickname", pc_nickname_input }, { "description", "" } });
+        pc_selected_index = players.size() - 1;
+        pc_nickname_input.clear();
+        pc_description_input.clear();
+        pending_save = true;
+    }
+
+    if (pc_selected_index < players.size()) {
+        gui::widgets::text(regular_font, common_font_size, 0, "Заметка об игроке «{}»:",
+                           players[pc_selected_index].value("nickname", std::string()));
+
+        if (ImGui::InputTextMultiline("##presets_pc_desc", &pc_description_input, { full_width, 60 })) {
+            players[pc_selected_index]["description"] = pc_description_input;
+            pending_save = true;
+        }
+
+        if (gui::widgets::button("Удалить выбранного##presets_pc_del", { full_width, buttons_height }).render()) {
+            players.erase(pc_selected_index);
+            pc_selected_index = 0;
+            pc_description_input.clear();
+            pending_save = true;
+        }
+    }
+}
+
+auto plugin::gui::windows::main::frames::presets::frame_renderer(std::string& label, std::any&) -> void {
+    std::size_t current = submenu.get_current_entry_index();
+    nlohmann::json& preset = preset_list[current];
+    std::string index = std::to_string(current);
+    float full_width = ImGui::GetContentRegionAvail().x;
+
+    ImGui::PushFont(regular_font, common_font_size);
+    {
+        render_editable_name(label, preset["name"].get_ref<std::string&>());
+        render_status_banner(preset, current);
+        ImGui::Separator();
+
+        bool active_and_applied = static_cast<int>(current) == get_active_index() && preset_matches_live(preset);
+        std::string apply_label = active_and_applied ? "Применить заново" : "Применить";
+
+        if (gui::widgets::button(apply_label + "##frames::presets-" + index, { full_width, buttons_height }).render()) {
+            apply_preset(preset);
+            set_active_index(static_cast<int>(current));
+        }
+
+        if (gui::widgets::button("Обновить значения из текущих##frames::presets-" + index,
+                                 { full_width, buttons_height }).render())
+        {
+            refresh_values(preset);
+            save_presets();
+
+            // Редакторы хоткеев кэшируют бинды — форсируем их перестройку, чтобы они
+            // подхватили обновлённые из текущих значения.
+            hotkey_editors_preset_id = -1;
+        }
+
+        if (gui::widgets::button("Удалить##frames::presets-" + index, { full_width, buttons_height }).render())
+            submenu.remove_current_entry();
+
+        if (gui::hotkey* preset_hotkey = find_pool_hotkey(preset_hotkey_label(preset.value("id", -1)))) {
+            gui::widgets::text(regular_font, common_font_size, 0, "Горячая клавиша применения:");
+            preset_hotkey->render({ full_width, buttons_height });
+            gui::widgets::hint::render_as_guide("ЛКМ — задать клавишу, ПКМ — условия активации");
+        }
+
+        ImGui::Dummy({ 0, ImGui::GetStyle().ItemSpacing.y });
+
+        render_editor(preset);
+    }
+    ImGui::PopFont();
+}
+
+auto plugin::gui::windows::main::frames::presets::add_callback() -> void {
+    int id = next_id++;
+
+    nlohmann::json preset = {
+        { "id", id },
+        { "name", "Новый пресет" },
+        { "settings", capture_all() }
+    };
+
+    preset_list.push_back(std::move(preset));
+    register_preset_hotkey(id);
+
+    submenu.add_entry_animated(preset_list.back()["name"].get<std::string>(),
+                               std::make_any<nlohmann::json&>(preset_list.back()));
+    save_presets();
+}
+
+auto plugin::gui::windows::main::frames::presets::on_entry_destroyed(std::size_t index) -> void {
+    int active = get_active_index();
+
+    if (active == static_cast<int>(index))
+        set_active_index(-1);
+    else if (active > static_cast<int>(index))
+        set_active_index(active - 1);
+
+    // Освобождаем горячую клавишу удаляемого пресета: обнуляем бинд в пуле и в конфиге.
+    int id = preset_list[index].value("id", -1);
+
+    if (id >= 0) {
+        std::string label = preset_hotkey_label(id);
+
+        if (gui::hotkey* pooled = find_pool_hotkey(label))
+            pooled->bind = {};
+
+        (*configuration)["internal"]["hotkeys"].erase(label);
+    }
+
+    preset_list.erase(index);
+    save_presets();
+}
+
+auto plugin::gui::windows::main::frames::presets::render() -> void {
+    // Раскладка: настройки слева, сайдбар со списком пресетов справа. Поскольку фрейм
+    // по умолчанию занимает всё доступное место, при отрисовке слева задаём ему явную
+    // ширину (всё минус ширина сайдбара и отступ).
+    float frame_width = ImGui::GetContentRegionAvail().x
+                        - submenu.get_menu_width(child) - ImGui::GetStyle().ItemSpacing.x;
+
+    submenu.render_current_frame(child, frame_width);
+    ImGui::SameLine();
+    submenu.render_menu(child);
+    popup.render(child);
+
+    // Отложенная запись: пишем файл, только когда пользователь отпустил слайдер/поле,
+    // иначе при перетаскивании ползунка файл писался бы каждый кадр.
+    if (pending_save && !ImGui::IsAnyItemActive()) {
+        save_presets();
+        pending_save = false;
+    }
+}
+
+plugin::gui::windows::main::frames::presets::presets(types::not_null<initializer*> child)
+    : child(child),
+      bold_font(child->child->fonts->bold),
+      regular_font(child->child->fonts->regular),
+      icon_font(child->child->fonts->icon)
+{
+#ifdef USE_EMBEDDED_MESSAGE_PACK
+    options = nlohmann::ordered_json::from_msgpack(options_bytes);
+#else
+    options = nlohmann::ordered_json::parse(options_bytes);
+#endif // USE_EMBEDDED_MESSAGE_PACK
+
+    presets_file = common::get_game_path() / "gadmin" / "configuration" / "presets.json";
+    load_presets();
+    ensure_preset_ids();
+
+    for (auto& preset : preset_list)
+        register_preset_hotkey(preset["id"].get<int>());
+
+    using namespace std::placeholders;
+
+    submenu.set_frame_renderer(std::bind(&presets::frame_renderer, this, _1, _2));
+    submenu.set_on_entry_destroyed_callback(std::bind(&presets::on_entry_destroyed, this, _1));
+    submenu.set_add_callback(std::bind(&presets::add_callback, this));
+
+    // Активный пресет подсвечиваем заливкой его кнопки в списке: зелёная — применён и
+    // совпадает с текущими настройками, жёлтая — применён, но настройки изменены вручную.
+    submenu.set_entry_highlight([this](std::size_t index) -> std::optional<std::uint32_t> {
+        if (static_cast<int>(index) != get_active_index() || index >= preset_list.size())
+            return std::nullopt;
+
+        style::accent_colors_t& accents = style::get_current_accent_colors();
+        std::uint32_t base = preset_matches_live(preset_list[index]) ? *accents.green : *accents.yellow;
+
+        // Полупрозрачная заливка — но достаточно яркая, чтобы активный пресет выделялся.
+        return (base & 0x00FFFFFFu) | (0xAAu << 24);
+    });
+
+    // На кнопке пресета справа рисуем бейдж с назначенной горячей клавишей применения.
+    submenu.set_entry_overlay([this](std::size_t index, const ImVec2& min, const ImVec2& max) {
+        std::optional<std::string> text = entry_hotkey_text(index);
+
+        if (!text)
+            return;
+
+        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+
+        ImGui::PushFont(regular_font, badge_font_size);
+        {
+            ImVec2 text_size = ImGui::CalcTextSize(text->c_str());
+            ImVec2 badge_size = { text_size.x + badge_padding_x * 2.0f, text_size.y + badge_padding_y * 2.0f };
+
+            ImVec2 badge_min = { max.x - badge_right_margin - badge_size.x,
+                                 min.y + (max.y - min.y - badge_size.y) / 2.0f };
+            ImVec2 badge_max = { badge_min.x + badge_size.x, badge_min.y + badge_size.y };
+
+            float rounding = ImGui::GetStyle().FrameRounding;
+
+            draw_list->AddRectFilled(badge_min, badge_max, ImGui::GetColorU32(ImGuiCol_FrameBg), rounding);
+            draw_list->AddRect(badge_min, badge_max, ImGui::GetColorU32(ImGuiCol_FrameBgActive), rounding);
+            draw_list->AddText({ badge_min.x + badge_padding_x, badge_min.y + badge_padding_y },
+                               ImGui::GetColorU32(ImGuiCol_Text), text->c_str());
+        }
+        ImGui::PopFont();
+    });
+
+    // Резервируем под бейдж место справа, чтобы название пресета не залезало под него.
+    submenu.set_entry_text_reserve([this](std::size_t index) -> float {
+        std::optional<std::string> text = entry_hotkey_text(index);
+
+        if (!text)
+            return 0.0f;
+
+        ImGui::PushFont(regular_font, badge_font_size);
+        float text_width = ImGui::CalcTextSize(text->c_str()).x;
+        ImGui::PopFont();
+
+        return text_width + badge_padding_x * 2.0f + badge_right_margin + badge_text_gap;
+    });
+
+    for (auto& preset : preset_list)
+        submenu.add_entry(preset["name"].get<std::string>(), std::make_any<nlohmann::json&>(preset));
+}

--- a/src/plugin/gui/windows/main/frames/presets.cpp
+++ b/src/plugin/gui/windows/main/frames/presets.cpp
@@ -23,12 +23,6 @@
 #include "plugin/gui/widgets/text.h"
 #include "plugin/gui/widgets/text_button.h"
 #include "plugin/gui/widgets/toggle_button.h"
-#include "plugin/gui/windows/main/base/custom_setting.h"
-#include "plugin/gui/windows/main/custom_settings/message_recolorer.h"
-#include "plugin/gui/windows/main/custom_settings/report.h"
-#include "plugin/gui/windows/main/custom_settings/short_commands.h"
-#include "plugin/gui/windows/main/custom_settings/spectator_actions.h"
-#include "plugin/gui/windows/main/custom_settings/spectator_information.h"
 #include "plugin/gui/style.h"
 #include "plugin/gui/icon.h"
 #include "plugin/gui/notify.h"
@@ -38,8 +32,8 @@
 #include "common/common.h"
 #include <misc/cpp/imgui_stdlib.h>
 #include <algorithm>
-#include <array>
 #include <fstream>
+#include <system_error>
 #include <utility>
 
 static constexpr std::uint8_t options_bytes[] = {
@@ -55,7 +49,9 @@ static constexpr std::uint8_t options_bytes[] = {
 auto plugin::gui::windows::main::frames::presets::load_presets() -> void {
     preset_list = nlohmann::json::array();
 
-    if (!std::filesystem::exists(presets_file))
+    std::error_code error_code;
+
+    if (!std::filesystem::exists(presets_file, error_code))
         return;
 
     std::ifstream file(presets_file);
@@ -135,42 +131,19 @@ auto plugin::gui::windows::main::frames::presets::capture_player_checker() const
     return nlohmann::json::array();
 }
 
-auto plugin::gui::windows::main::frames::presets::refresh_values(nlohmann::json& preset) const -> void {
-    if (!preset.contains("settings"))
-        return;
-
-    for (auto& [ section, items ] : preset["settings"].items()) {
-        // Спец-блоки (хоткеи, чекер) живут не как одноимённые секции конфига — обновляем их отдельно.
-        if (section == "hotkeys" || section == "player_checker")
-            continue;
-
-        nlohmann::json& live_section = (*configuration)[section];
-
-        for (auto& [ item, value ] : items.items())
-            if (live_section.contains(item))
-                value = live_section[item];
-    }
-
-    if (preset["settings"].contains("hotkeys"))
-        preset["settings"]["hotkeys"] = capture_hotkeys();
-
-    if (preset["settings"].contains("player_checker"))
-        preset["settings"]["player_checker"] = capture_player_checker();
-}
-
 auto plugin::gui::windows::main::frames::presets::apply_preset(const nlohmann::json& preset) const -> void {
     if (!preset.contains("settings"))
         return;
 
     const nlohmann::json& settings = preset["settings"];
 
-    // merge_patch посекционно: ключи, которых в пресете нет (исключённые элементы, пароли,
-    // более новые настройки), остаются в живом конфиге нетронутыми.
+    // merge_patch per section: keys absent from the preset (excluded items, passwords,
+    // newer settings) stay untouched in the live config.
     for (types::zstring_t section : captured_sections)
         if (settings.contains(section))
             (*configuration)[section].merge_patch(settings.at(section));
 
-    // Спец-блоки: список чекера и хоткеи лежат по своим путям, применяем их явно.
+    // Special blocks: the checker list and hotkeys live at their own paths, apply explicitly.
     if (settings.contains("player_checker"))
         (*configuration)["windows"]["player_checker"]["players"] = settings.at("player_checker");
 
@@ -180,7 +153,7 @@ auto plugin::gui::windows::main::frames::presets::apply_preset(const nlohmann::j
         for (const auto& [ label, packed ] : settings.at("hotkeys").items()) {
             live_hotkeys[label] = packed;
 
-            // Обновляем живой объект хоткея, чтобы бинд применился сразу, без перезапуска.
+            // Update the live hotkey object so the bind applies at once, without a restart.
             if (gui::hotkey* pooled = find_pool_hotkey(label))
                 pooled->bind = gui::key_bind(packed.get<std::uint32_t>());
         }
@@ -203,8 +176,8 @@ auto plugin::gui::windows::main::frames::presets::preset_matches_live(const nloh
         return false;
 
     for (const auto& [ section, items ] : preset["settings"].items()) {
-        // Хоткеи и список чекера не участвуют в сравнении (их сопоставление сложнее
-        // и не влияет на маркер «применён/изменён»).
+        // Hotkeys and the checker list are excluded from the comparison (matching them is
+        // harder and does not affect the applied/modified marker).
         if (section == "hotkeys" || section == "player_checker")
             continue;
 
@@ -244,7 +217,7 @@ auto plugin::gui::windows::main::frames::presets::render_status_banner(const nlo
         text  = "Не применён";
     }
 
-    // Иконку рисуем шрифтом `icon` (в regular её глифов нет — иначе «?»), текст — обычным.
+    // Draw the icon with the `icon` font (regular lacks its glyphs — would show "?"), text with regular.
     ImVec2 pos = ImGui::GetCursorScreenPos();
     float line_height = ImGui::GetTextLineHeight();
     ImVec2 glyph_size = icon_font->CalcTextSizeA(common_font_size, FLT_MAX, 0.0f, glyph);
@@ -350,173 +323,21 @@ auto plugin::gui::windows::main::frames::presets::render_editable_name(std::stri
     gui::widgets::hint::render_as_guide("Нажмите на имя, чтобы переименовать пресет");
 }
 
-auto plugin::gui::windows::main::frames::presets::render_variant(const std::string& id, nlohmann::ordered_json& config,
-                                                                 nlohmann::json& value) -> void
-{
-    if (!value.is_string())
-        return;
-
-    std::string& setter = value.get_ref<std::string&>();
-    int current = 0;
-
-    for (std::size_t index = 0; index < config.size(); index++)
-        if (config[index][0] == setter) {
-            current = static_cast<int>(index);
-            break;
-        }
-
-    std::string format = config[current][1];
-
-    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-
-    if (ImGui::SliderInt(id.c_str(), &current, 0, static_cast<int>(config.size()) - 1, format.c_str())) {
-        setter = config[current][0].get<std::string>();
-        pending_save = true;
-    }
-}
-
-auto plugin::gui::windows::main::frames::presets::render_color(const std::string& id, nlohmann::json& value) -> void {
-    types::color color = value.get<types::color>();
-    ImVec4 vector_color = ImGui::ColorConvertU32ToFloat4(*color);
-
-    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-
-    if (ImGui::ColorEdit3(id.c_str(), reinterpret_cast<float*>(&vector_color), ImGuiColorEditFlags_NoInputs)) {
-        value = types::color(ImGui::ColorConvertFloat4ToU32(vector_color));
-        pending_save = true;
-    }
-}
-
-auto plugin::gui::windows::main::frames::presets::render_custom(const std::string& custom_id, nlohmann::json& value)
-    -> void
-{
-    static auto custom_settings = std::to_array<custom_setting_ptr_t>({
-        std::make_unique<custom_settings::report>(),
-        std::make_unique<custom_settings::short_commands>(),
-        std::make_unique<custom_settings::spectator_information>(),
-        std::make_unique<custom_settings::spectator_actions>(),
-        std::make_unique<custom_settings::message_recolorer>()
-    }); // static auto custom_settings = std::to_array<custom_setting_ptr_t>({ ... })
-
-    auto setting = std::find_if(custom_settings.begin(), custom_settings.end(),
-        [&custom_id](const custom_setting_ptr_t& setting) { return setting->get_id() == custom_id; });
-
-    if (setting == custom_settings.end()) {
-        log::error("presets::render_custom: custom setting \"{}\" not found", custom_id);
-        return;
-    }
-
-    // У custom-редакторов нет сигнала об изменении — сравниваем дамп до/после (значение небольшое).
-    std::string before = value.dump();
-    (*setting)->render(child->child, value);
-
-    if (value.dump() != before)
-        pending_save = true;
-}
-
-auto plugin::gui::windows::main::frames::presets::render_option(const std::string& id, const std::string& key,
-                                                                const std::string& subsection_key,
-                                                                nlohmann::ordered_json& meta_option, nlohmann::json& parent)
-    -> void
-{
-    if (!parent.contains(key))
-        return;
-
-    item_type type = meta_option["_type"];
-    std::string name = meta_option["_name"];
-    std::string widget_id = "##opt:" + id;
-    nlohmann::json& value = parent[key];
-    float available = ImGui::GetContentRegionAvail().x;
-
-    switch (type) {
-        case item_type::boolean:
-            if (value.is_boolean() && gui::widgets::toggle_button(widget_id, value.get_ref<bool&>()).render())
-                pending_save = true;
-
-            ImGui::SameLine();
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-            break;
-
-        case item_type::int_range: {
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-
-            nlohmann::ordered_json& config = meta_option["_config"];
-            int minimum = config[0].get<int>(), maximum = config[1].get<int>();
-            int current = static_cast<int>(value.get<long long>());
-
-            ImGui::SetNextItemWidth(available);
-
-            if (ImGui::SliderInt(widget_id.c_str(), &current, minimum, maximum)) {
-                value = static_cast<std::uint64_t>(current);
-                pending_save = true;
-            }
-
-            break;
-        }
-
-        case item_type::float_range: {
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-
-            nlohmann::ordered_json& config = meta_option["_config"];
-            double minimum = config[0].get<double>(), maximum = config[1].get<double>();
-            double current = value.get<double>();
-
-            ImGui::SetNextItemWidth(available);
-
-            if (ImGui::SliderScalar(widget_id.c_str(), ImGuiDataType_Double, &current, &minimum, &maximum, "%.3f")) {
-                value = current;
-                pending_save = true;
-            }
-
-            break;
-        }
-
-        case item_type::variant:
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-            render_variant(widget_id, meta_option["_config"], value);
-            break;
-
-        case item_type::color:
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-            render_color(widget_id, value);
-            break;
-
-        case item_type::input:
-            if (auto* setter = value.get_ptr<std::string*>()) {
-                gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-                ImGui::SetNextItemWidth(available);
-
-                if (ImGui::InputText(widget_id.c_str(), setter))
-                    pending_save = true;
-            }
-
-            break;
-
-        case item_type::custom:
-            gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
-            render_custom(subsection_key + "." + key, value);
-            break;
-
-        default:
-            break;
-    }
-}
-
 auto plugin::gui::windows::main::frames::presets::open_subsection_popup(const std::string& section,
                                                                         const std::string& item,
                                                                         const std::string& name,
                                                                         nlohmann::ordered_json& meta_item,
                                                                         nlohmann::json& settings) -> void
 {
-    // Захватываем указатели на стабильные узлы: meta_item живёт в `options` (член класса),
-    // а ветка значения — в текущем пресете (не перевыделяется, пока попап открыт).
+    // Capture pointers to stable nodes: meta_item lives in `options` (a class member) and the
+    // value branch lives in the current preset (not reallocated while the popup is open).
     nlohmann::json* value = &settings[section][item];
     nlohmann::ordered_json* meta = &meta_item;
     std::string subsection_key = item;
     std::string title = name;
 
     popup.set_renderer([this, value, meta, subsection_key, title] {
-        // Имя пресета читаем «вживую» по текущей записи — переименование подхватится сразу.
+        // Read the preset name live from the current entry, so a rename is reflected at once.
         std::size_t current = submenu.get_current_entry_index();
         std::string preset_name = current < preset_list.size()
             ? preset_list[current].value("name", std::string("пресет")) : std::string("пресет");
@@ -530,12 +351,20 @@ auto plugin::gui::windows::main::frames::presets::open_subsection_popup(const st
 
         ImGui::PushFont(regular_font, common_font_size);
         {
-            // `use` редактируется тумблером в строке списка, поэтому в попапе только опции.
+            // `use` is toggled from the list row, so the popup shows only the options. Reuse the
+            // settings frame's widget renderer (live = false: a preset edit has no side effects).
             for (auto& [ key, meta_option ] : meta->items()) {
-                if (key.starts_with('_'))
+                if (key.starts_with('_') || !value->contains(key))
                     continue;
 
-                render_option(subsection_key + ":" + key, key, subsection_key, meta_option, *value);
+                nlohmann::json& option_value = (*value)[key];
+                std::string before = option_value.dump();
+
+                owner->render_option_widget("##opt:" + subsection_key + ":" + key,
+                                            subsection_key + "." + key, meta_option, option_value, false);
+
+                if (option_value.dump() != before)
+                    pending_save = true;
             }
         }
         ImGui::PopFont();
@@ -550,7 +379,7 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
 {
     std::string section_name = meta_section["_name"];
 
-    // При активном поиске пропускаем разделы без совпадений и форсируем раскрытие остальных.
+    // While searching, skip sections with no match and force-expand the rest.
     if (!editor_search.empty()) {
         bool any_match = false;
 
@@ -583,8 +412,8 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
 
         std::string id = section + ":" + item;
 
-        // Пресет — полный снимок настроек. Если значения ещё нет (старый пресет или
-        // настройка, добавленная позже), берём актуальное из живого конфига.
+        // A preset is a full settings snapshot. If a value is missing (old preset or a
+        // setting added later), take the current one from the live config.
         if (!settings.contains(section) || !settings[section].contains(item)) {
             include_item(section, item, settings);
             pending_save = true;
@@ -592,7 +421,7 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
 
         nlohmann::json& value = settings[section][item];
 
-        // Подсекция: тумблер `use` + кликабельное имя, открывающее детальный попап — ровно как в «Настройках».
+        // Subsection: a `use` toggle + a clickable name opening the detail popup — just like in Settings.
         if (type == item_type::subsection) {
             if (value.contains("use") && value["use"].is_boolean()) {
                 if (gui::widgets::toggle_button("##use:" + id, value["use"].get_ref<bool&>()).render())
@@ -609,7 +438,7 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
             continue;
         }
 
-        // Bool-функция: тумблер значения + имя.
+        // Boolean option: a value toggle + the name.
         if (type == item_type::boolean && value.is_boolean()) {
             if (gui::widgets::toggle_button("##val:" + id, value.get_ref<bool&>()).render())
                 pending_save = true;
@@ -619,7 +448,7 @@ auto plugin::gui::windows::main::frames::presets::render_section_editor(const st
             continue;
         }
 
-        // На верхнем уровне секции иных типов нет, но на всякий случай покажем имя.
+        // No other types exist at the section top level, but show the name just in case.
         ImGui::AlignTextToFramePadding();
         gui::widgets::text(regular_font, common_font_size, 0, "{}", name);
     }
@@ -631,7 +460,7 @@ auto plugin::gui::windows::main::frames::presets::include_item(const std::string
     settings[section][item] = snapshot_item(section, item);
 }
 
-auto plugin::gui::windows::main::frames::presets::render_editor(nlohmann::json& preset) -> void {
+auto plugin::gui::windows::main::frames::presets::render_editor(nlohmann::json& preset, float bottom_reserve) -> void {
     if (!preset.contains("settings") || !preset["settings"].is_object())
         preset["settings"] = nlohmann::json::object();
 
@@ -644,7 +473,8 @@ auto plugin::gui::windows::main::frames::presets::render_editor(nlohmann::json& 
 
     editor_search.render(full_width, "Поиск функции по названию...");
 
-    ImGui::BeginChild("presets::editor", { 0, 0 }, ImGuiChildFlags_Borders);
+    // Negative height: fill the remaining space minus the action-button footer below.
+    ImGui::BeginChild("presets::editor", { 0, -bottom_reserve }, ImGuiChildFlags_Borders);
     {
         ImGui::PushFont(regular_font, common_font_size);
         {
@@ -690,13 +520,13 @@ auto plugin::gui::windows::main::frames::presets::render_hotkeys_section(nlohman
     nlohmann::json& hotkeys = settings["hotkeys"];
     ensure_hotkey_editors(hotkeys, preset_id);
 
-    // Каждый кадр освежаем указатель на хранилище: preset_list (json-массив) может
-    // перевыделиться при добавлении пресета, и закэшированный в редакторах указатель
-    // на settings["hotkeys"] стал бы висячим (use-after-free).
+    // Refresh the storage pointer every frame: preset_list (a json array) may be reallocated
+    // when a preset is added, which would leave the editors' cached pointer to
+    // settings["hotkeys"] dangling (use-after-free).
     for (gui::hotkey& editor : hotkey_editors)
         editor.set_external_storage(&hotkeys);
 
-    // При активном поиске показываем секцию только если есть совпадения по меткам хоткеев.
+    // While searching, show the section only if some hotkey label matches.
     if (!editor_search.empty()) {
         bool any_match = false;
 
@@ -717,8 +547,8 @@ auto plugin::gui::windows::main::frames::presets::render_hotkeys_section(nlohman
 
     gui::widgets::hint::render_as_guide("ЛКМ — задать клавишу, ПКМ — условия активации (в слежке, на /alogin и т.д.).");
 
-    // Хоткей-виджет пишет бинд прямо в JSON пресета через внешнее хранилище. Сравниваем
-    // дамп до/после, чтобы отметить пресет на сохранение при любом изменении.
+    // The hotkey widget writes the bind straight into the preset JSON via external storage.
+    // Compare the dump before/after to mark the preset for saving on any change.
     std::string before = hotkeys.dump();
 
     for (gui::hotkey& editor : hotkey_editors) {
@@ -729,8 +559,8 @@ auto plugin::gui::windows::main::frames::presets::render_hotkeys_section(nlohman
         ImGui::SameLine();
         ImGui::AlignTextToFramePadding();
 
-        // Подпись — кликабельный текст (с подсветкой при наведении, как в других вкладках):
-        // ЛКМ открывает тот же попап условий активации, что и ПКМ по кнопке клавиши.
+        // The label is clickable text (hover-highlighted, as on other tabs): a left click
+        // opens the same activation-conditions popup as a right click on the key button.
         if (gui::widgets::text_button(editor.label).render())
             editor.open_conditions_popup();
     }
@@ -745,7 +575,7 @@ auto plugin::gui::windows::main::frames::presets::render_player_checker_section(
         pending_save = true;
     }
 
-    // Список игроков — отдельная сущность, под фильтр функций не подводим.
+    // The player list is a separate entity, not subject to the option filter.
     if (!editor_search.empty())
         return;
 
@@ -814,39 +644,47 @@ auto plugin::gui::windows::main::frames::presets::frame_renderer(std::string& la
     {
         render_editable_name(label, preset["name"].get_ref<std::string&>());
         render_status_banner(preset, current);
-        ImGui::Separator();
 
-        bool active_and_applied = static_cast<int>(current) == get_active_index() && preset_matches_live(preset);
-        std::string apply_label = active_and_applied ? "Применить заново" : "Применить";
-
-        if (gui::widgets::button(apply_label + "##frames::presets-" + index, { full_width, buttons_height }).render()) {
-            apply_preset(preset);
-            set_active_index(static_cast<int>(current));
-        }
-
-        if (gui::widgets::button("Обновить значения из текущих##frames::presets-" + index,
-                                 { full_width, buttons_height }).render())
-        {
-            refresh_values(preset);
-            save_presets();
-
-            // Редакторы хоткеев кэшируют бинды — форсируем их перестройку, чтобы они
-            // подхватили обновлённые из текущих значения.
-            hotkey_editors_preset_id = -1;
-        }
-
-        if (gui::widgets::button("Удалить##frames::presets-" + index, { full_width, buttons_height }).render())
-            submenu.remove_current_entry();
-
+        // The single key that applies this whole preset.
         if (gui::hotkey* preset_hotkey = find_pool_hotkey(preset_hotkey_label(preset.value("id", -1)))) {
             gui::widgets::text(regular_font, common_font_size, 0, "Горячая клавиша применения:");
             preset_hotkey->render({ full_width, buttons_height });
             gui::widgets::hint::render_as_guide("ЛКМ — задать клавишу, ПКМ — условия активации");
         }
 
-        ImGui::Dummy({ 0, ImGui::GetStyle().ItemSpacing.y });
+        ImGui::Separator();
 
-        render_editor(preset);
+        // The bordered settings editor fills the middle, leaving room for the stacked action
+        // footer below (three full-width buttons + the spacing between them).
+        float spacing = ImGui::GetStyle().ItemSpacing.y;
+        float footer_reserve = buttons_height * 3.0f + spacing * 3.0f;
+        render_editor(preset, footer_reserve);
+
+        // Action buttons stacked full-width: apply / write the current settings into the preset / delete.
+        bool active_and_applied = static_cast<int>(current) == get_active_index() && preset_matches_live(preset);
+        std::string apply_label = active_and_applied ? "Применить заново" : "Применить";
+        ImVec2 button_size = { full_width, buttons_height };
+
+        if (gui::widgets::button(apply_label + "##frames::presets-apply-" + index, button_size)
+                .without_click_animation().render())
+        {
+            apply_preset(preset);
+            set_active_index(static_cast<int>(current));
+        }
+
+        if (gui::widgets::button("Записать текущие настройки##frames::presets-write-" + index, button_size)
+                .without_click_animation().render())
+        {
+            preset["settings"] = capture_all();
+            save_presets();
+
+            // The hotkey editors cache binds — force a rebuild so they pick up the new values.
+            hotkey_editors_preset_id = -1;
+        }
+
+        if (gui::widgets::button("Удалить##frames::presets-delete-" + index, button_size)
+                .without_click_animation().render())
+            submenu.remove_current_entry();
     }
     ImGui::PopFont();
 }
@@ -876,7 +714,7 @@ auto plugin::gui::windows::main::frames::presets::on_entry_destroyed(std::size_t
     else if (active > static_cast<int>(index))
         set_active_index(active - 1);
 
-    // Освобождаем горячую клавишу удаляемого пресета: обнуляем бинд в пуле и в конфиге.
+    // Free the deleted preset's hotkey: clear its bind in the pool and in the config.
     int id = preset_list[index].value("id", -1);
 
     if (id >= 0) {
@@ -893,27 +731,23 @@ auto plugin::gui::windows::main::frames::presets::on_entry_destroyed(std::size_t
 }
 
 auto plugin::gui::windows::main::frames::presets::render() -> void {
-    // Раскладка: настройки слева, сайдбар со списком пресетов справа. Поскольку фрейм
-    // по умолчанию занимает всё доступное место, при отрисовке слева задаём ему явную
-    // ширину (всё минус ширина сайдбара и отступ).
-    float frame_width = ImGui::GetContentRegionAvail().x
-                        - submenu.get_menu_width(child) - ImGui::GetStyle().ItemSpacing.x;
-
-    submenu.render_current_frame(child, frame_width);
-    ImGui::SameLine();
+    // Layout: the preset-list sidebar on the left, the selected preset's detail on the right.
     submenu.render_menu(child);
+    ImGui::SameLine();
+    submenu.render_current_frame(child);
     popup.render(child);
 
-    // Отложенная запись: пишем файл, только когда пользователь отпустил слайдер/поле,
-    // иначе при перетаскивании ползунка файл писался бы каждый кадр.
+    // Deferred write: save the file only once the user releases the slider/field, otherwise
+    // dragging a slider would write the file every frame.
     if (pending_save && !ImGui::IsAnyItemActive()) {
         save_presets();
         pending_save = false;
     }
 }
 
-plugin::gui::windows::main::frames::presets::presets(types::not_null<initializer*> child)
+plugin::gui::windows::main::frames::presets::presets(types::not_null<initializer*> child, types::not_null<settings*> owner)
     : child(child),
+      owner(owner),
       bold_font(child->child->fonts->bold),
       regular_font(child->child->fonts->regular),
       icon_font(child->child->fonts->icon)
@@ -937,20 +771,20 @@ plugin::gui::windows::main::frames::presets::presets(types::not_null<initializer
     submenu.set_on_entry_destroyed_callback(std::bind(&presets::on_entry_destroyed, this, _1));
     submenu.set_add_callback(std::bind(&presets::add_callback, this));
 
-    // Активный пресет подсвечиваем заливкой его кнопки в списке: зелёная — применён и
-    // совпадает с текущими настройками, жёлтая — применён, но настройки изменены вручную.
-    submenu.set_entry_highlight([this](std::size_t index) -> std::optional<std::uint32_t> {
+    // Highlight the active preset by filling its list button: green — applied and matching
+    // the current settings, yellow — applied but the settings were changed manually.
+    submenu.set_entry_highlight([this](std::size_t index) -> types::color {
         if (static_cast<int>(index) != get_active_index() || index >= preset_list.size())
-            return std::nullopt;
+            return types::color();
 
         style::accent_colors_t& accents = style::get_current_accent_colors();
         std::uint32_t base = preset_matches_live(preset_list[index]) ? *accents.green : *accents.yellow;
 
-        // Полупрозрачная заливка — но достаточно яркая, чтобы активный пресет выделялся.
-        return (base & 0x00FFFFFFu) | (0xAAu << 24);
+        // Semi-transparent fill, but bright enough for the active preset to stand out.
+        return types::color(types::color::abgr((base & 0x00FFFFFFu) | (0xAAu << 24)));
     });
 
-    // На кнопке пресета справа рисуем бейдж с назначенной горячей клавишей применения.
+    // Draw a badge with the assigned apply hotkey on the right of the preset button.
     submenu.set_entry_overlay([this](std::size_t index, const ImVec2& min, const ImVec2& max) {
         std::optional<std::string> text = entry_hotkey_text(index);
 
@@ -978,7 +812,7 @@ plugin::gui::windows::main::frames::presets::presets(types::not_null<initializer
         ImGui::PopFont();
     });
 
-    // Резервируем под бейдж место справа, чтобы название пресета не залезало под него.
+    // Reserve space on the right for the badge so the preset name does not run under it.
     submenu.set_entry_text_reserve([this](std::size_t index) -> float {
         std::optional<std::string> text = entry_hotkey_text(index);
 

--- a/src/plugin/gui/windows/main/frames/settings.cpp
+++ b/src/plugin/gui/windows/main/frames/settings.cpp
@@ -113,56 +113,14 @@ auto plugin::gui::windows::main::frames::settings::render_subsection(const std::
         return;
 
     popup.set_renderer([=, this, &item_configuration, &item] {
-        float region_avail_x = ImGui::GetContentRegionAvail().x;
-        
         gui::widgets::text(bold_font, section_title_font_size, 0, "{}", subsection_name);
 
         for (auto& [ key, option ] : item.items()) {
             if (key.starts_with('_'))
                 continue;
 
-            item_type option_type = option["_type"];
-            std::string option_name = option["_name"];
-            std::string option_label = option_name + "##" + subsection_key;
-            nlohmann::ordered_json config = option["_config"];
-
-            if (option_type != item_type::boolean) {
-                gui::widgets::text(bold_font, common_text_size, 0, "{}", option_name);
-                option_label.insert(0, "##");
-            }
-
-            ImGui::PushFont(regular_font, common_text_size);
-            {
-                switch (option_type) {
-                    case item_type::int_range:
-                        render_range<std::uint64_t>(option_label.c_str(), item_configuration[key].get_ptr<std::uint64_t*>(),
-                                                    std::make_pair(config[0], config[1]));
-                        break;
-                    case item_type::float_range:
-                        render_range<double>(option_label.c_str(), item_configuration[key].get_ptr<double*>(),
-                                             std::make_pair(config[0], config[1]));
-                        break;
-                    case item_type::boolean:
-                        render_boolean(option_label, config, item_configuration[key].get_ref<bool&>());
-                        break;
-                    case item_type::input:
-                        ImGui::SetNextItemWidth(region_avail_x);
-                        ImGui::InputText(option_label.c_str(), item_configuration[key].get_ptr<std::string*>());
-                        break;
-                    case item_type::variant:
-                        render_variant(option_label, config, item_configuration[key].get_ref<std::string&>());
-                        break;
-                    case item_type::color:
-                        render_color(option_label, item_configuration[key]);
-                        break;
-                    case item_type::custom:
-                        render_custom(std::format("{}.{}", subsection_key, key), item_configuration[key]);
-                        break;
-                    default:
-                        break;
-                }
-            }
-            ImGui::PopFont();
+            render_option_widget("##" + std::string(subsection_key), std::format("{}.{}", subsection_key, key),
+                                 option, item_configuration[key], true);
         }
     });
 
@@ -269,6 +227,60 @@ auto plugin::gui::windows::main::frames::settings::render_boolean(const std::str
     toggle_events[config](setter);
 }
 
+auto plugin::gui::windows::main::frames::settings::render_option_widget(const std::string& widget_id,
+                                                                        const std::string& custom_id,
+                                                                        nlohmann::ordered_json& meta_option,
+                                                                        nlohmann::json& value, bool live) const -> void
+{
+    item_type type = meta_option["_type"];
+    std::string name = meta_option["_name"];
+    nlohmann::ordered_json config = meta_option["_config"];
+    std::string label = name + widget_id;
+
+    if (type != item_type::boolean) {
+        gui::widgets::text(bold_font, common_text_size, 0, "{}", name);
+        label.insert(0, "##");
+    }
+
+    ImGui::PushFont(regular_font, common_text_size);
+    {
+        switch (type) {
+            case item_type::int_range:
+                render_range<std::uint64_t>(label.c_str(), value.get_ptr<std::uint64_t*>(),
+                                            std::make_pair(config[0], config[1]));
+                break;
+            case item_type::float_range:
+                render_range<double>(label.c_str(), value.get_ptr<double*>(),
+                                     std::make_pair(config[0], config[1]));
+                break;
+            case item_type::boolean:
+                // A preset snapshot is not the live state, so its toggles must not fire the
+                // side-effecting toggle events (e.g. enabling wallhack) — only flip the value.
+                if (live)
+                    render_boolean(label, config, value.get_ref<bool&>());
+                else
+                    gui::widgets::toggle_button(label, value.get_ref<bool&>()).render();
+                break;
+            case item_type::input:
+                ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+                ImGui::InputText(label.c_str(), value.get_ptr<std::string*>());
+                break;
+            case item_type::variant:
+                render_variant(label, config, value.get_ref<std::string&>());
+                break;
+            case item_type::color:
+                render_color(label, value);
+                break;
+            case item_type::custom:
+                render_custom(custom_id, value);
+                break;
+            default:
+                break;
+        }
+    }
+    ImGui::PopFont();
+}
+
 auto plugin::gui::windows::main::frames::settings::render() -> void {
     submenu.render_menu(child);
     ImGui::SameLine();
@@ -292,7 +304,7 @@ plugin::gui::windows::main::frames::settings::settings(types::not_null<initializ
                           std::make_any<nlohmann::ordered_json&>(section));
     }
 
-    presets_component = std::make_unique<presets>(child);
+    presets_component = std::make_unique<presets>(child, this);
     submenu.add_entry(std::string("Пресеты##") + presets_section_key, std::make_any<int>(0));
 
     submenu.set_frame_renderer([this](std::string& label, std::any& payload) {

--- a/src/plugin/gui/windows/main/frames/settings.cpp
+++ b/src/plugin/gui/windows/main/frames/settings.cpp
@@ -27,6 +27,7 @@
 #include "plugin/gui/windows/main/custom_settings/short_commands.h"
 #include "plugin/gui/windows/main/custom_settings/spectator_actions.h"
 #include "plugin/gui/windows/main/custom_settings/spectator_information.h"
+#include "plugin/gui/windows/main/frames/presets.h"
 #include "plugin/server/user.h"
 #include "plugin/plugin.h"
 #include <misc/cpp/imgui_stdlib.h>
@@ -291,13 +292,21 @@ plugin::gui::windows::main::frames::settings::settings(types::not_null<initializ
                           std::make_any<nlohmann::ordered_json&>(section));
     }
 
+    presets_component = std::make_unique<presets>(child);
+    submenu.add_entry(std::string("Пресеты##") + presets_section_key, std::make_any<int>(0));
+
     submenu.set_frame_renderer([this](std::string& label, std::any& payload) {
         std::size_t pos = label.find("##");
 
         [[assume(pos != std::string_view::npos)]];
-        
+
         std::string name = label.substr(0, pos);
         std::string key = label.substr(pos + 2);
+
+        if (key == presets_section_key) {
+            presets_component->render();
+            return;
+        }
 
         gui::widgets::text(bold_font, section_title_font_size, 0, "{}", name);
         ImGui::PushFont(regular_font, common_text_size);
@@ -309,3 +318,5 @@ plugin::gui::windows::main::frames::settings::settings(types::not_null<initializ
         ImGui::PopFont();
     });
 }
+
+plugin::gui::windows::main::frames::settings::~settings() = default;

--- a/src/plugin/gui/windows/main/initializer.cpp
+++ b/src/plugin/gui/windows/main/initializer.cpp
@@ -185,6 +185,10 @@ plugin::gui::windows::main::initializer::initializer(types::not_null<gui_initial
 
     child->hotkey_handler->add(switch_hotkey);
 
+    // Защита от сохранённого индекса больше не существующей вкладки (напр. удалённой «Пресеты»).
+    if (std::to_underlying(active_frame) >= frames_count)
+        active_frame = frame::home;
+
     frames = {
         std::make_unique<frames::home>(this),
         std::make_unique<frames::settings>(this),

--- a/src/plugin/gui/windows/main/initializer.cpp
+++ b/src/plugin/gui/windows/main/initializer.cpp
@@ -185,7 +185,7 @@ plugin::gui::windows::main::initializer::initializer(types::not_null<gui_initial
 
     child->hotkey_handler->add(switch_hotkey);
 
-    // Защита от сохранённого индекса больше не существующей вкладки (напр. удалённой «Пресеты»).
+    // Guard against a saved index of a tab that no longer exists (e.g. a removed preset tab).
     if (std::to_underlying(active_frame) >= frames_count)
         active_frame = frame::home;
 

--- a/src/plugin/gui/windows/main/widgets/submenu.cpp
+++ b/src/plugin/gui/windows/main/widgets/submenu.cpp
@@ -26,8 +26,8 @@
 #include <ranges>
 
 auto plugin::gui::windows::main::widgets::submenu::get_next_available_entry_index() const -> std::size_t {
-    // После удаления текущей записи останется entries.size() - 1 элементов. Выбираем
-    // соседа слева (или 0). Аккуратно с беззнаковым переполнением при size <= 1.
+    // After removing the current entry, entries.size() - 1 will remain. Pick the left
+    // neighbour (or 0). Mind the unsigned underflow when size <= 1.
     if (entries.size() <= 1)
         return 0;
 
@@ -37,7 +37,7 @@ auto plugin::gui::windows::main::widgets::submenu::get_next_available_entry_inde
     return std::min(current_entry_index - 1, entries.size() - 2);
 }
 
-// Обрезает строку по ширине (с «...»), не разрывая UTF-8-символы (важно для кириллицы).
+// Truncate a string to a width (with "..."), without splitting UTF-8 characters (matters for Cyrillic).
 static auto truncate_to_width(std::string text, float max_width) -> std::string {
     if (max_width <= 0.0f || ImGui::CalcTextSize(text.c_str()).x <= max_width)
         return text;
@@ -63,8 +63,8 @@ auto plugin::gui::windows::main::widgets::submenu::render_entry(std::size_t inde
                                           entry.animation_time, entry_animation_duration);
     
         if (entry.hiding && entry.alpha == 0) {
-            // Удаляем именно эту запись (по её индексу), но не во время итерации —
-            // откладываем до конца цикла отрисовки в render_menu.
+            // Remove this exact entry (by its index), but not during iteration —
+            // defer it until the end of the render loop in render_menu.
             entry_to_destroy = index;
             return;
         }
@@ -72,15 +72,15 @@ auto plugin::gui::windows::main::widgets::submenu::render_entry(std::size_t inde
 
     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, entry.alpha * ImGui::GetStyle().Alpha);
     {
-        std::optional<std::uint32_t> highlight = entry_highlight ? (*entry_highlight)(index) : std::nullopt;
+        types::color highlight = entry_highlight ? (*entry_highlight)(index) : types::color();
 
-        if (highlight)
+        if (*highlight != 0)
             ImGui::PushStyleColor(ImGuiCol_Button, *highlight);
 
         std::string visible = label_decorator ? (*label_decorator)(index, entry.label) : entry.label;
 
-        // Если задано резервирование (под бейдж-оверлей), выравниваем подписи влево и
-        // обрезаем длинное название, чтобы текст не залезал под оверлей справа.
+        // When reserving is set (for a badge overlay), left-align labels and truncate
+        // long names so the text does not run under the overlay on the right.
         bool reserve_enabled = entry_text_reserve.has_value();
 
         if (reserve_enabled) {
@@ -100,7 +100,7 @@ auto plugin::gui::windows::main::widgets::submenu::render_entry(std::size_t inde
         if (reserve_enabled)
             ImGui::PopStyleVar();
 
-        if (highlight)
+        if (*highlight != 0)
             ImGui::PopStyleColor();
 
         if (entry_overlay)
@@ -211,7 +211,7 @@ auto plugin::gui::windows::main::widgets::submenu::render_menu(types::not_null<i
             for (const auto& [ index, entry ] : entries | std::views::enumerate)
                 render_entry(index, entry, button_size);
 
-            // Отложенное удаление записи, чья анимация исчезновения завершилась.
+            // Deferred removal of the entry whose fade-out animation has finished.
             if (entry_to_destroy && *entry_to_destroy < entries.size()) {
                 std::size_t dead = *entry_to_destroy;
                 entry_to_destroy.reset();

--- a/src/plugin/gui/windows/main/widgets/submenu.cpp
+++ b/src/plugin/gui/windows/main/widgets/submenu.cpp
@@ -26,7 +26,35 @@
 #include <ranges>
 
 auto plugin::gui::windows::main::widgets::submenu::get_next_available_entry_index() const -> std::size_t {
-    return std::max<std::size_t>(0, std::min(current_entry_index - 1, entries.size() - 2));
+    // После удаления текущей записи останется entries.size() - 1 элементов. Выбираем
+    // соседа слева (или 0). Аккуратно с беззнаковым переполнением при size <= 1.
+    if (entries.size() <= 1)
+        return 0;
+
+    if (current_entry_index == 0)
+        return 0;
+
+    return std::min(current_entry_index - 1, entries.size() - 2);
+}
+
+// Обрезает строку по ширине (с «...»), не разрывая UTF-8-символы (важно для кириллицы).
+static auto truncate_to_width(std::string text, float max_width) -> std::string {
+    if (max_width <= 0.0f || ImGui::CalcTextSize(text.c_str()).x <= max_width)
+        return text;
+
+    static constexpr std::string_view ellipsis = "...";
+
+    while (!text.empty() && ImGui::CalcTextSize((text + std::string(ellipsis)).c_str()).x > max_width) {
+        std::size_t pos = text.size();
+
+        do {
+            --pos;
+        } while (pos > 0 && (static_cast<unsigned char>(text[pos]) & 0xC0) == 0x80);
+
+        text.erase(pos);
+    }
+
+    return text + std::string(ellipsis);
 }
 
 auto plugin::gui::windows::main::widgets::submenu::render_entry(std::size_t index, entry_t& entry, const ImVec2& size) -> void {
@@ -35,23 +63,48 @@ auto plugin::gui::windows::main::widgets::submenu::render_entry(std::size_t inde
                                           entry.animation_time, entry_animation_duration);
     
         if (entry.hiding && entry.alpha == 0) {
-            if (on_entry_destroy_callback.has_value())
-                (*on_entry_destroy_callback)(current_entry_index);
-
-            entries.erase(entries.begin() + current_entry_index);
-            
+            // Удаляем именно эту запись (по её индексу), но не во время итерации —
+            // откладываем до конца цикла отрисовки в render_menu.
+            entry_to_destroy = index;
             return;
         }
     }
 
     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, entry.alpha * ImGui::GetStyle().Alpha);
     {
-        if (gui::widgets::button(entry.label + "##submenu::" + std::to_string(index), size).render()
+        std::optional<std::uint32_t> highlight = entry_highlight ? (*entry_highlight)(index) : std::nullopt;
+
+        if (highlight)
+            ImGui::PushStyleColor(ImGuiCol_Button, *highlight);
+
+        std::string visible = label_decorator ? (*label_decorator)(index, entry.label) : entry.label;
+
+        // Если задано резервирование (под бейдж-оверлей), выравниваем подписи влево и
+        // обрезаем длинное название, чтобы текст не залезал под оверлей справа.
+        bool reserve_enabled = entry_text_reserve.has_value();
+
+        if (reserve_enabled) {
+            float reserve = (*entry_text_reserve)(index);
+
+            ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, { 0.0f, 0.5f });
+            visible = truncate_to_width(visible, size.x - reserve - ImGui::GetStyle().FramePadding.x * 2.0f);
+        }
+
+        if (gui::widgets::button(visible + "##submenu::" + std::to_string(index), size).render()
             && index != future_entry_index)
         {
             future_entry_index = index;
             time_clicked = std::chrono::steady_clock::now();
         }
+
+        if (reserve_enabled)
+            ImGui::PopStyleVar();
+
+        if (highlight)
+            ImGui::PopStyleColor();
+
+        if (entry_overlay)
+            (*entry_overlay)(index, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
     }
     ImGui::PopStyleVar();
 }
@@ -97,6 +150,11 @@ auto plugin::gui::windows::main::widgets::submenu::remove_current_entry_animated
     entry.hiding = true;
 }
 
+auto plugin::gui::windows::main::widgets::submenu::remove_current_entry() -> void {
+    if (current_entry_index < entries.size())
+        entry_to_destroy = current_entry_index;
+}
+
 auto plugin::gui::windows::main::widgets::submenu::set_on_entry_destroyed_callback(on_entry_destroy_callback_t new_callback) -> void {
     on_entry_destroy_callback = std::move(new_callback);
 }
@@ -109,8 +167,28 @@ auto plugin::gui::windows::main::widgets::submenu::set_frame_renderer(frame_rend
     frame_renderer = std::move(new_frame_renderer);
 }
 
+auto plugin::gui::windows::main::widgets::submenu::set_label_decorator(label_decorator_t new_decorator) -> void {
+    label_decorator = std::move(new_decorator);
+}
+
+auto plugin::gui::windows::main::widgets::submenu::set_entry_highlight(entry_highlight_t new_highlight) -> void {
+    entry_highlight = std::move(new_highlight);
+}
+
+auto plugin::gui::windows::main::widgets::submenu::set_entry_overlay(entry_overlay_t new_overlay) -> void {
+    entry_overlay = std::move(new_overlay);
+}
+
+auto plugin::gui::windows::main::widgets::submenu::set_entry_text_reserve(entry_text_reserve_t new_reserve) -> void {
+    entry_text_reserve = std::move(new_reserve);
+}
+
+auto plugin::gui::windows::main::widgets::submenu::get_menu_width(types::not_null<initializer*> child) const -> float {
+    return (child_width_percent * child->window_size.x) / 100.0f;
+}
+
 auto plugin::gui::windows::main::widgets::submenu::render_menu(types::not_null<initializer*> child) -> void {
-    float child_width = (child_width_percent * child->window_size.x) / 100.0f;
+    float child_width = get_menu_width(child);
 
     ImGui::BeginChild(label.c_str(), { child_width, 0 }, ImGuiChildFlags_AlwaysUseWindowPadding, child->window_flags);
     {
@@ -132,6 +210,30 @@ auto plugin::gui::windows::main::widgets::submenu::render_menu(types::not_null<i
 
             for (const auto& [ index, entry ] : entries | std::views::enumerate)
                 render_entry(index, entry, button_size);
+
+            // Отложенное удаление записи, чья анимация исчезновения завершилась.
+            if (entry_to_destroy && *entry_to_destroy < entries.size()) {
+                std::size_t dead = *entry_to_destroy;
+                entry_to_destroy.reset();
+
+                if (on_entry_destroy_callback.has_value())
+                    (*on_entry_destroy_callback)(dead);
+
+                entries.erase(entries.begin() + dead);
+
+                auto clamp_index = [this, dead](std::size_t& value) {
+                    if (value > dead)
+                        --value;
+
+                    if (value >= entries.size())
+                        value = entries.empty() ? 0 : entries.size() - 1;
+                };
+
+                clamp_index(current_entry_index);
+                clamp_index(future_entry_index);
+            } else {
+                entry_to_destroy.reset();
+            }
         }
         ImGui::EndChild();
 
@@ -141,7 +243,8 @@ auto plugin::gui::windows::main::widgets::submenu::render_menu(types::not_null<i
     ImGui::EndChild();
 }
 
-auto plugin::gui::windows::main::widgets::submenu::render_current_frame(types::not_null<initializer*> child) -> void {
+auto plugin::gui::windows::main::widgets::submenu::render_current_frame(types::not_null<initializer*> child,
+                                                                        float frame_width) -> void {
     auto now = std::chrono::steady_clock::now();
     ImGuiWindowFlags flags = child->window_flags | ImGuiWindowFlags_NoBackground;
 
@@ -160,7 +263,7 @@ auto plugin::gui::windows::main::widgets::submenu::render_current_frame(types::n
     }
 
     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, frame_alpha * ImGui::GetStyle().Alpha);
-    ImGui::BeginChild((label + "::current_frame").c_str(), { 0, 0 }, ImGuiChildFlags_None, flags);
+    ImGui::BeginChild((label + "::current_frame").c_str(), { frame_width, 0 }, ImGuiChildFlags_None, flags);
     {
         if (current_entry_index >= entries.size()) {
             ImGui::PushFont(child->child->fonts->bold, empty_placeholder_font_size);

--- a/src/plugin/misc/features/me_to_id.cpp
+++ b/src/plugin/misc/features/me_to_id.cpp
@@ -1,0 +1,55 @@
+/// GAdmin - Plugin simplifying the work of administrators on the Gambit-RP
+/// Copyright (C) 2023-2026 The Contributors.
+///
+/// This program is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program. If not, see <https://www.gnu.org/licenses/>.
+///
+/// SPDX-License-Identifier: GPL-3.0-only
+
+#include "plugin/misc/features/me_to_id.h"
+#include "plugin/samp/core/user.h"
+#include "plugin/types/string_iterator.h"
+#include "plugin/plugin.h"
+
+#include <cctype>
+#include <string>
+
+auto plugin::misc::features::me_to_id::on_send_command(const samp::out_event<samp::event_id::send_command>& event) const
+    -> bool
+{
+    if (!(*configuration)["misc"]["me_to_id"])
+        return true;
+
+    types::string_iterator iterator(event.command, 1);
+
+    std::string command_name = iterator.collect([](unsigned char c) { return !std::isspace(c); });
+    std::string separator    = iterator.collect([](unsigned char c) { return  std::isspace(c); });
+    std::string first_argument = iterator.collect([](unsigned char c) { return !std::isspace(c); });
+
+    if (first_argument != "me")
+        return true;
+
+    std::string rest = iterator.remaining();
+    std::string new_command = command_name + separator + std::to_string(samp::user::get_id()) + rest;
+
+    event.write_command('/' + new_command);
+
+    return true;
+}
+
+auto plugin::misc::features::me_to_id::on_event(const samp::event_info& event) -> bool {
+    if (event == samp::event_type::outgoing_rpc && event == samp::event_id::send_command)
+        return on_send_command(event.create<samp::event_id::send_command, samp::event_type::outgoing_rpc>());
+
+    return true;
+}

--- a/src/plugin/misc/features/me_to_id.cpp
+++ b/src/plugin/misc/features/me_to_id.cpp
@@ -20,7 +20,6 @@
 #include "plugin/samp/core/user.h"
 #include "plugin/types/string_iterator.h"
 #include "plugin/plugin.h"
-
 #include <cctype>
 #include <string>
 

--- a/src/plugin/misc/misc.cpp
+++ b/src/plugin/misc/misc.cpp
@@ -9,6 +9,7 @@
 #include "plugin/misc/features/fixes.h"
 #include "plugin/misc/features/hide_addresses.h"
 #include "plugin/misc/features/information_render.h"
+#include "plugin/misc/features/me_to_id.h"
 #include "plugin/misc/features/mentions.h"
 #include "plugin/misc/features/message_recolorer.h"
 #include "plugin/misc/features/nickname_colors.h"
@@ -66,6 +67,7 @@ plugin::misc::initializer::initializer() {
     features.push_back(std::make_unique<features::fixes>());
     features.push_back(std::make_unique<features::death_notify_in_chat>());
     features.push_back(std::make_unique<features::short_commands>());
+    features.push_back(std::make_unique<features::me_to_id>());
     features.push_back(std::make_unique<features::fish_eye>());
     features.push_back(std::make_unique<features::statistics_updater>());
     features.push_back(std::make_unique<features::information_render>());


### PR DESCRIPTION
Привет, предлагаю три новых фичи:


1. Пресеты настроек. Сохранение текущей конфигурации скрипта (значения функций + горячие клавиши + список чекера игроков) в именованный пресет и применение одной кнопкой. Встроена секцией во фрейм «Настройки», редактор повторяет привычный экран настроек; хоткеи и чекер редактируются в пресете независимо от живых и применяются только по кнопке «Применить». Активный пресет подсвечивается, можно вешать на горячую клавишу. Пароли в пресет не сохраняются.

2. Отключение наведения на объект слежки (toggle key в круговом меню). Новая опция interaction_area.ignore_spectated_target (вкл. по умолчанию): круговая панель перестаёт наводиться на игрока/транспорт под слежкой. Тогл клавишей 0.

3. Замена "me" в командах на свой ID. /aheal me → /aheal 14 (только для первого аргумента команды; /me и текст сообщений не трогаются). Настройка: опция misc.me_to_id в разделе «Прочее» gui.