### PR TITLE
fix(presets): keep live state in sync when applying and editing presets

### DIFF
--- a/src/plugin/gui/windows/main/frames/presets.cpp
+++ b/src/plugin/gui/windows/main/frames/presets.cpp
@@ -27,6 +27,8 @@
 #include "plugin/gui/icon.h"
 #include "plugin/gui/notify.h"
 #include "plugin/types/color.h"
+#include "plugin/cheats/wallhack.h"
+#include "plugin/server/user.h"
 #include "plugin/plugin.h"
 #include "plugin/log.h"
 #include "common/common.h"
@@ -157,6 +159,20 @@ auto plugin::gui::windows::main::frames::presets::apply_preset(const nlohmann::j
             if (gui::hotkey* pooled = find_pool_hotkey(label))
                 pooled->bind = gui::key_bind(packed.get<std::uint32_t>());
         }
+    }
+
+    // merge_patch only rewrites the JSON; it does not run the side-effect handlers the
+    // settings UI fires on toggle. Wallhack is the only setting whose live runtime state
+    // (the `cheat_active` flag + server name-tag render) is more than its config value, so
+    // reconcile it explicitly — otherwise the cheat keeps its pre-apply state against the
+    // preset and its hotkey desyncs (a disabled-by-preset wallhack stays rendered and its
+    // toggle gets blocked by the `use` gate). Mirror the settings toggle: switch the active
+    // state only on /alogin, but always refresh the renderers for `custom_render` changes.
+    if (settings.contains("cheats") && settings.at("cheats").contains("wallhack")) {
+        if (server::user::is_on_alogin())
+            cheats::wallhack::toggle((*configuration)["cheats"]["wallhack"]["use"].get<bool>());
+        else
+            cheats::wallhack::update();
     }
 
     configuration->save();
@@ -737,6 +753,13 @@ auto plugin::gui::windows::main::frames::presets::render() -> void {
     if (pending_save && !ImGui::IsAnyItemActive()) {
         save_presets();
         pending_save = false;
+
+        // Editing the active preset mirrors the live settings screen: push the change to the
+        // live configuration at once, so there is no need to press "Apply" again.
+        std::size_t current = submenu.get_current_entry_index();
+
+        if (current < preset_list.size() && static_cast<int>(current) == get_active_index())
+            apply_preset(preset_list[current]);
     }
 }
 

--- a/src/plugin/gui/windows/main/frames/settings.cpp
+++ b/src/plugin/gui/windows/main/frames/settings.cpp
@@ -130,26 +130,22 @@ auto plugin::gui::windows::main::frames::settings::render_subsection(const std::
 auto plugin::gui::windows::main::frames::settings::render_variant(const std::string& label, nlohmann::ordered_json& config, std::string& setter) const
     -> void
 {
-    static std::unordered_map<std::string, int> pool;
+    // Resolve the index from the live value every frame, so a change made outside this widget
+    // (e.g. applying a preset) is reflected at once, with no stale per-label cache.
+    auto it = std::find_if(config.begin(), config.end(), [&setter](nlohmann::ordered_json& array) {
+        return array[0] == setter;
+    });
 
-    if (!pool.contains(label)) {
-        auto it = std::find_if(config.begin(), config.end(), [&setter](nlohmann::ordered_json& array) {
-            return array[0] == setter;
-        });
-
-        if (it == config.end()) {
-            log::fatal("settings::render_variant: `{}` is not found in `config`", setter);
-            return;
-        }
-
-        pool[label] = std::distance(config.begin(), it);
+    if (it == config.end()) {
+        log::fatal("settings::render_variant: `{}` is not found in `config`", setter);
+        return;
     }
 
-    int& index = pool[label];
+    int index = std::distance(config.begin(), it);
     std::string format = config[index][1];
 
     ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-    
+
     if (ImGui::SliderInt(label.c_str(), &index, 0, config.size() - 1, format.c_str()))
         setter = config[index][0];
 }
@@ -157,12 +153,10 @@ auto plugin::gui::windows::main::frames::settings::render_variant(const std::str
 auto plugin::gui::windows::main::frames::settings::render_color(const std::string& label, nlohmann::json& setter) const
     -> void
 {
-    static std::unordered_map<std::string, ImVec4> pool;
-
-    if (!pool.contains(label))
-        pool[label] = ImGui::ColorConvertU32ToFloat4(*setter.get<types::color>());
-
-    ImVec4& vector_color = pool[label];
+    // Edit buffer derived from the live value every frame, so a change made outside this widget
+    // (e.g. applying a preset) is reflected at once, with no stale per-label cache. ImGui keeps
+    // the in-progress HSV state by widget id, so a transient buffer does not affect editing.
+    ImVec4 vector_color = ImGui::ColorConvertU32ToFloat4(*setter.get<types::color>());
 
     ImGui::PushFont(bold_font, common_text_size);
     {


### PR DESCRIPTION
- apply_preset reconciles the wallhack runtime state (merge_patch alone left its render/hotkey out of sync with the config)
- variant/color widgets read the live value each frame instead of a stale per-label cache
- editing the active preset applies changes live, without re-applying