### PR TITLE
feat(presets): widen the window on the presets tab

### DIFF
--- a/include/plugin/gui/windows/main/base/frame.h
+++ b/include/plugin/gui/windows/main/base/frame.h
@@ -32,6 +32,9 @@ public:
     /// Render the frame.
     virtual auto render() -> void = 0;
 
+    /// Whether this frame needs the wider window layout (see initializer). Defaults to no.
+    virtual auto wants_wide_window() const -> bool { return false; }
+
     /// Process SA:MP event.
     /// 
     /// @param event[in] SA-MP event information.

--- a/include/plugin/gui/windows/main/frames/settings.h
+++ b/include/plugin/gui/windows/main/frames/settings.h
@@ -55,6 +55,9 @@ private:
     /// Embedded presets manager rendered when the presets section is selected.
     std::unique_ptr<presets> presets_component;
 
+    /// Submenu index of the presets entry, used to widen the window on that sub-tab.
+    std::size_t presets_entry_index = 0;
+
     ImFont* bold_font = nullptr;
     ImFont* regular_font = nullptr;
 
@@ -92,6 +95,9 @@ public:
     }; // enum class item_type : std::uint8_t
 
     auto render() -> void override;
+
+    /// The presets editor needs the wider window layout; other settings sections do not.
+    auto wants_wide_window() const -> bool override;
 
     /// Construct the frame.
     ///

--- a/include/plugin/gui/windows/main/initializer.h
+++ b/include/plugin/gui/windows/main/initializer.h
@@ -52,6 +52,12 @@ private:
 
     auto on_send_command(const samp::out_event<samp::event_id::send_command>& event) -> bool;
 public:
+    /// Window size in frame heights. The presets tab widens the window for its editor; the
+    /// selector is pinned to the default width (see frame_selector), so only the editor grows.
+    static constexpr float default_width_frame_heights = 29.0f;
+    static constexpr float presets_width_frame_heights = 32.0f;
+    static constexpr float window_height_frame_heights = 18.0f;
+
     /// Currently active frame.
     frame active_frame = frame::home;
 

--- a/src/plugin/gui/windows/main/frames/settings.cpp
+++ b/src/plugin/gui/windows/main/frames/settings.cpp
@@ -299,6 +299,7 @@ plugin::gui::windows::main::frames::settings::settings(types::not_null<initializ
     }
 
     presets_component = std::make_unique<presets>(child, this);
+    presets_entry_index = submenu.get_total_entries();
     submenu.add_entry(std::string("Пресеты##") + presets_section_key, std::make_any<int>(0));
 
     submenu.set_frame_renderer([this](std::string& label, std::any& payload) {
@@ -323,6 +324,10 @@ plugin::gui::windows::main::frames::settings::settings(types::not_null<initializ
         ImGui::EndGroup();
         ImGui::PopFont();
     });
+}
+
+auto plugin::gui::windows::main::frames::settings::wants_wide_window() const -> bool {
+    return submenu.get_current_entry_index() == presets_entry_index;
 }
 
 plugin::gui::windows::main::frames::settings::~settings() = default;

--- a/src/plugin/gui/windows/main/initializer.cpp
+++ b/src/plugin/gui/windows/main/initializer.cpp
@@ -148,7 +148,12 @@ auto plugin::gui::windows::main::initializer::render() -> void {
     float frame_height = ImGui::GetFrameHeight();
 
     ImGui::SetNextWindowPos({ size_x / 2.0f, size_y / 2.0f }, ImGuiCond_FirstUseEver, { 0.5f, 0.5f });
-    ImGui::SetNextWindowSize({ 29 * frame_height, 18 * frame_height });
+    // Let the active frame ask for the wider layout (only the presets editor does); other tabs
+    // keep the default width.
+    bool wide = frames[std::to_underlying(active_frame)]->wants_wide_window();
+    float width_frame_heights = wide ? presets_width_frame_heights : default_width_frame_heights;
+
+    ImGui::SetNextWindowSize({ width_frame_heights * frame_height, window_height_frame_heights * frame_height });
 
     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, window_alpha / 255.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });

--- a/src/plugin/gui/windows/main/widgets/frame_selector.cpp
+++ b/src/plugin/gui/windows/main/widgets/frame_selector.cpp
@@ -23,7 +23,10 @@
 #include "plugin/gui/widgets/text.h"
 
 auto plugin::gui::windows::main::widgets::frame_selector::compute_width_on_state(bool state) const -> float {
-    return (default_percentage_on_state[state] * child->window_size.x) / 100.0f;
+    // Anchor the selector to the default window width, not the live one: the presets tab widens
+    // the window, and we want the side selector (and its icons) to stay put — only the editor grows.
+    float base_width = initializer::default_width_frame_heights * ImGui::GetFrameHeight();
+    return (default_percentage_on_state[state] * base_width) / 100.0f;
 }
 
 auto plugin::gui::windows::main::widgets::frame_selector::update_state_width() -> void {


### PR DESCRIPTION
Привет. Из-за того что названия некоторых функций довольно широкие, в фиксированное по размеру окно настройки пресета они не влезали. Сделал так, расширил только окно пресета немного, если надо по другому логику переделать скажи.

"The presets editor sits behind two side lists (settings sections and the preset list), leaving it too narrow for long option labels. The active frame now reports whether it needs the wider layout via
basic_frame::wants_wide_window(), and the window widens only for the presets sub-tab. The frame selector is pinned to the default window width so its icons stay put and the extra room goes to the editor alone."